### PR TITLE
Simulator api

### DIFF
--- a/numba_rvsdg/tests/simulator.py
+++ b/numba_rvsdg/tests/simulator.py
@@ -49,13 +49,13 @@ class Simulator:
         Python variable map more or less a register
     ctrl_varmap: Dict[Str, int]
         Control variable map
-    self.stack: List[Instruction]
+    stack: List[Instruction]
         Instruction stack
-    self.region_stack: List[RegionBlocks]
+    region_stack: List[RegionBlocks]
         Stack to hold the recusion level for regions
-    self.branch: Boolean
+    branch: Boolean
         Flag to be set during execution.
-    self.return_value: Any
+    return_value: Any
         The return value of the function.
 
     """
@@ -102,7 +102,7 @@ class Simulator:
             return self.flow.bbmap[label]
 
     def run(self, args):
-        """Run the given simulator with gievn args.
+        """Run the given simulator with given args.
 
         Parameters
         ----------

--- a/numba_rvsdg/tests/simulator.py
+++ b/numba_rvsdg/tests/simulator.py
@@ -163,7 +163,7 @@ class Simulator:
         return the action when we jump out of the region or when we return from
         within the region.
 
-        Sepcial attention is directed at the use of the `region_stack` here.
+        Special attention is directed at the use of the `region_stack` here.
         Since the blocks for the subregion are stored in the `region.subregion`
         graph, we need to use a region aware `get_blocks` in methods such as
         `run_BasicBlock` so that we get the correct `BasicBlock`. The net effect


### PR DESCRIPTION
This simplifies the `run*` methods in the simulator such that only a
`Label` and not both `Label` and `BasicBlock` must be supplied. The
Simulator received a new attribute `region_stack` which memoizes the
current region and allows for a region aware `get_block` for any
simulator run. This significantly reduces code overhead and creates a
simple, easy to use API when iterating through the program.


depends on #14 