### PR TITLE
Added yaml and dictionary conversion methods to BlockMap

### DIFF
--- a/numba_rvsdg/core/datastructures/block_map.py
+++ b/numba_rvsdg/core/datastructures/block_map.py
@@ -1,5 +1,6 @@
 import dis
 import yaml
+from textwrap import dedent
 from typing import Set, Tuple, Dict, List, Iterator
 from dataclasses import dataclass, field
 
@@ -351,13 +352,16 @@ class BlockMap:
             jump_targets = [f"{i.index}" for i in value._jump_targets]
             jump_targets = str(jump_targets).replace("\'", "\"")
             back_edges = [f"{i.index}" for i in value.backedges]
-            yaml_string += f"""
-    "{str(key.index)}":
-        jt: {jump_targets}"""         
+            jump_target_str= f"""
+                "{str(key.index)}":
+                    jt: {jump_targets}"""
+            yaml_string += dedent(jump_target_str)
             if back_edges:
                 back_edges = str(back_edges).replace("\'", "\"")
-                yaml_string += f"""
-        be: {back_edges}"""
+                back_edge_str = f"""
+                    be: {back_edges}"""
+                yaml_string += dedent(back_edge_str)
+
         return yaml_string
 
     def to_dict(self):

--- a/numba_rvsdg/core/datastructures/block_map.py
+++ b/numba_rvsdg/core/datastructures/block_map.py
@@ -355,12 +355,12 @@ class BlockMap:
             jump_target_str= f"""
                 "{str(key.index)}":
                     jt: {jump_targets}"""
-            yaml_string += dedent(jump_target_str)
+
             if back_edges:
                 back_edges = str(back_edges).replace("\'", "\"")
-                back_edge_str = f"""
+                jump_target_str += f"""
                     be: {back_edges}"""
-                yaml_string += dedent(back_edge_str)
+            yaml_string += dedent(jump_target_str)
 
         return yaml_string
 

--- a/numba_rvsdg/core/datastructures/block_map.py
+++ b/numba_rvsdg/core/datastructures/block_map.py
@@ -1,4 +1,5 @@
 import dis
+import yaml
 from typing import Set, Tuple, Dict, List, Iterator
 from dataclasses import dataclass, field
 
@@ -15,6 +16,7 @@ from numba_rvsdg.core.datastructures.labels import (
     SyntheticExit,
     SyntheticTail,
     SyntheticReturn,
+    ControlLabel
 )
 
 
@@ -318,3 +320,56 @@ class BlockMap:
     @staticmethod
     def bcmap_from_bytecode(bc: dis.Bytecode):
         return {inst.offset: inst for inst in bc}
+
+    @staticmethod
+    def from_yaml(yaml_string):
+        data = yaml.safe_load(yaml_string)
+        return BlockMap.from_dict(data)
+
+    @staticmethod
+    def from_dict(graph_dict):        
+        block_map_graph = {}
+        clg = ControlLabelGenerator()
+        for index, attributes in graph_dict.items():
+            jump_targets = attributes["jt"]
+            backedges = attributes.get("be", ())
+            label = ControlLabel(str(clg.new_index()))
+            block = BasicBlock(
+                label=label,
+                backedges=wrap_id(backedges),
+                _jump_targets=wrap_id(jump_targets),
+            )
+            block_map_graph[label] = block
+        return BlockMap(block_map_graph, clg=clg)
+
+    def to_yaml(self):
+        # Convert to yaml
+        block_map_graph = self.graph
+        yaml_string = """"""
+
+        for key, value in block_map_graph.items():
+            jump_targets = [f"{i.index}" for i in value._jump_targets]
+            jump_targets = str(jump_targets).replace("\'", "\"")
+            back_edges = [f"{i.index}" for i in value.backedges]
+            yaml_string += f"""
+    "{str(key.index)}":
+        jt: {jump_targets}"""         
+            if back_edges:
+                back_edges = str(back_edges).replace("\'", "\"")
+                yaml_string += f"""
+        be: {back_edges}"""
+        return yaml_string
+
+    def to_dict(self):
+        block_map_graph = self.graph
+        graph_dict = {}
+        for key, value in block_map_graph.items():
+            curr_dict = {}
+            curr_dict["jt"] = [f"{i.index}" for i in value._jump_targets]
+            if value.backedges:
+                curr_dict["be"] = [f"{i.index}" for i in value.backedges]
+            graph_dict[str(key.index)] = curr_dict
+        return graph_dict
+
+def wrap_id(indices: Set[Label]):
+    return tuple([ControlLabel(i) for i in indices])

--- a/numba_rvsdg/tests/test_block_map.py
+++ b/numba_rvsdg/tests/test_block_map.py
@@ -12,7 +12,7 @@ class TestBlockMapIterator(MapComparator):
                                            _jump_targets=(ControlLabel("1"),))),
             (ControlLabel("1"), BasicBlock(label=ControlLabel("1"))),
         ]
-        block_map = self.from_yaml("""
+        block_map = BlockMap.from_yaml("""
         "0":
             jt: ["1"]
         "1":

--- a/numba_rvsdg/tests/test_blockmap.py
+++ b/numba_rvsdg/tests/test_blockmap.py
@@ -9,19 +9,19 @@ from numba_rvsdg.tests.test_utils import MapComparator
 class TestBlockMapConversion(MapComparator):
 
     def test_yaml_conversion(self):
-        # Case # 1
+        # Case # 1: Acyclic graph, no back-edges
         cases = ["""
     "0":
         jt: ["1", "2"]
     "1":
         jt: ["3"]
     "2":
-        jt: ["1", "4"]
+        jt: ["4"]
     "3":
-        jt: ["0"]
+        jt: ["4"]
     "4":
         jt: []""",
-        # Case # 2
+        # Case # 2: Cyclic graph, no back edges
         """
     "0":
         jt: ["1", "2"]
@@ -35,7 +35,7 @@ class TestBlockMapConversion(MapComparator):
         jt: []
     "5":
         jt: ["3", "4"]""",
-        # Case # 3
+        # Case # 3: Graph with backedges
         """
     "0":
         jt: ["1"]
@@ -54,19 +54,19 @@ class TestBlockMapConversion(MapComparator):
             self.assertEqual(case, block_map.to_yaml())
     
     def test_dict_conversion(self):
-        # Case # 1
+        # Case # 1: Acyclic graph, no back-edges
         cases = [{
     "0":
         {"jt": ["1", "2"]},
     "1":
         {"jt": ["3"]},
     "2":
-        {"jt": ["1", "4"]},
+        {"jt": ["4"]},
     "3":
-        {"jt": ["0"]},
+        {"jt": ["4"]},
     "4":
         {"jt": []}},
-        # Case # 2
+        # Case # 2: Cyclic graph, no back edges
         {
     "0":
         {"jt": ["1", "2"]},
@@ -80,7 +80,7 @@ class TestBlockMapConversion(MapComparator):
         {"jt": []},
     "5":
         {"jt": ["3", "4"]}},
-        # Case # 3
+        # Case # 3: Graph with backedges
         {
     "0":
         {"jt": ["1"]},

--- a/numba_rvsdg/tests/test_blockmap.py
+++ b/numba_rvsdg/tests/test_blockmap.py
@@ -1,0 +1,103 @@
+
+from unittest import main
+
+from numba_rvsdg.core.datastructures.block_map import BlockMap
+
+from numba_rvsdg.tests.test_utils import MapComparator
+
+
+class TestBlockMapConversion(MapComparator):
+
+    def test_yaml_conversion(self):
+        # Case # 1
+        cases = ["""
+    "0":
+        jt: ["1", "2"]
+    "1":
+        jt: ["3"]
+    "2":
+        jt: ["1", "4"]
+    "3":
+        jt: ["0"]
+    "4":
+        jt: []""",
+        # Case # 2
+        """
+    "0":
+        jt: ["1", "2"]
+    "1":
+        jt: ["5"]
+    "2":
+        jt: ["1", "5"]
+    "3":
+        jt: ["0"]
+    "4":
+        jt: []
+    "5":
+        jt: ["3", "4"]""",
+        # Case # 3
+        """
+    "0":
+        jt: ["1"]
+    "1":
+        jt: ["2", "3"]
+    "2":
+        jt: ["4"]
+    "3":
+        jt: []
+    "4":
+        jt: ["2", "3"]
+        be: ["2"]"""]
+
+        for case in cases:
+            block_map = BlockMap.from_yaml(case)
+            self.assertEqual(case, block_map.to_yaml())
+    
+    def test_dict_conversion(self):
+        # Case # 1
+        cases = [{
+    "0":
+        {"jt": ["1", "2"]},
+    "1":
+        {"jt": ["3"]},
+    "2":
+        {"jt": ["1", "4"]},
+    "3":
+        {"jt": ["0"]},
+    "4":
+        {"jt": []}},
+        # Case # 2
+        {
+    "0":
+        {"jt": ["1", "2"]},
+    "1":
+        {"jt": ["5"]},
+    "2":
+        {"jt": ["1", "5"]},
+    "3":
+        {"jt": ["0"]},
+    "4":
+        {"jt": []},
+    "5":
+        {"jt": ["3", "4"]}},
+        # Case # 3
+        {
+    "0":
+        {"jt": ["1"]},
+    "1":
+        {"jt": ["2", "3"]},
+    "2":
+        {"jt": ["4"]},
+    "3":
+        {"jt": []},
+    "4":
+        {"jt": ["2", "3"],
+        "be": ["2"]}}]
+
+        for case in cases:
+            block_map = BlockMap.from_dict(case)
+            self.assertEqual(case, block_map.to_dict())
+
+if __name__ == "__main__":
+    main()
+           

--- a/numba_rvsdg/tests/test_blockmap.py
+++ b/numba_rvsdg/tests/test_blockmap.py
@@ -1,6 +1,6 @@
 
 from unittest import main
-
+from textwrap import dedent
 from numba_rvsdg.core.datastructures.block_map import BlockMap
 
 from numba_rvsdg.tests.test_utils import MapComparator
@@ -11,45 +11,46 @@ class TestBlockMapConversion(MapComparator):
     def test_yaml_conversion(self):
         # Case # 1: Acyclic graph, no back-edges
         cases = ["""
-    "0":
-        jt: ["1", "2"]
-    "1":
-        jt: ["3"]
-    "2":
-        jt: ["4"]
-    "3":
-        jt: ["4"]
-    "4":
-        jt: []""",
+            "0":
+                jt: ["1", "2"]
+            "1":
+                jt: ["3"]
+            "2":
+                jt: ["4"]
+            "3":
+                jt: ["4"]
+            "4":
+                jt: []""",
         # Case # 2: Cyclic graph, no back edges
-        """
-    "0":
-        jt: ["1", "2"]
-    "1":
-        jt: ["5"]
-    "2":
-        jt: ["1", "5"]
-    "3":
-        jt: ["0"]
-    "4":
-        jt: []
-    "5":
-        jt: ["3", "4"]""",
+            """
+            "0":
+                jt: ["1", "2"]
+            "1":
+                jt: ["5"]
+            "2":
+                jt: ["1", "5"]
+            "3":
+                jt: ["0"]
+            "4":
+                jt: []
+            "5":
+                jt: ["3", "4"]""",
         # Case # 3: Graph with backedges
-        """
-    "0":
-        jt: ["1"]
-    "1":
-        jt: ["2", "3"]
-    "2":
-        jt: ["4"]
-    "3":
-        jt: []
-    "4":
-        jt: ["2", "3"]
-        be: ["2"]"""]
+            """
+            "0":
+                jt: ["1"]
+            "1":
+                jt: ["2", "3"]
+            "2":
+                jt: ["4"]
+            "3":
+                jt: []
+            "4":
+                jt: ["2", "3"]
+                be: ["2"]"""]
 
         for case in cases:
+            case = dedent(case)
             block_map = BlockMap.from_yaml(case)
             self.assertEqual(case, block_map.to_yaml())
     

--- a/numba_rvsdg/tests/test_utils.py
+++ b/numba_rvsdg/tests/test_utils.py
@@ -1,0 +1,21 @@
+from unittest import TestCase
+
+class MapComparator(TestCase):
+    def assertMapEqual(self, first_map, second_map):
+
+        for key1, key2 in zip(
+            sorted(first_map.graph.keys(), key=lambda x: x.index),
+            sorted(second_map.graph.keys(), key=lambda x: x.index),
+        ):
+            # compare indices of labels
+            self.assertEqual(key1.index, key2.index)
+            # compare indices of jump_targets
+            self.assertEqual(
+                sorted([j.index for j in first_map[key1]._jump_targets]),
+                sorted([j.index for j in second_map[key2]._jump_targets]),
+            )
+            # compare indices of backedges
+            self.assertEqual(
+                sorted([j.index for j in first_map[key1].backedges]),
+                sorted([j.index for j in second_map[key2].backedges]),
+            )


### PR DESCRIPTION
As titled, this PR makes the `from_yaml` method a staticmethod on `BlockMap`. Also adds a deserializer to convert `BlockMap` to yaml and a similar conversion in dictionary format as well.