### PR TITLE
refactor find_headers_and_entries

### DIFF
--- a/numba_rvsdg/core/datastructures/scfg.py
+++ b/numba_rvsdg/core/datastructures/scfg.py
@@ -121,8 +121,9 @@ class SCFG:
         return list(scc(GraphWrap(self.blocks, subgraph)))
 
     def find_headers_and_entries(
-        self, subgraph: Set[BlockName]
-    ) -> Tuple[Set[BlockName], Set[BlockName]]:
+            self,
+            subgraph: set[BlockName]
+            ) -> Tuple[list[BlockName], list[BlockName]]:
         """Find entries and headers in a given subgraph.
 
         Entries are blocks outside the subgraph that have an edge pointing to
@@ -131,23 +132,40 @@ class SCFG:
         subgraph. Entries point to headers and headers are pointed to by
         entries.
 
+        Parameters
+        ----------
+        subgraph: set of BlockName
+            The subgraph for which to find the headers and entries
+
+        Returns
+        -------
+        headers: list of BlockName
+            The headers for this subgraph
+        entries:
+            The entries for this subgraph
+
+        Notes
+        -----
+        The returned lists of headers and entries are sorted.
         """
         outside: BlockName
-        entries: Set[BlockName] = set()
-        headers: Set[BlockName] = set()
-
+        entries: Set[BlockName] = list()
+        headers: Set[BlockName] = list()
+        # Iterate over all blocks in the graph, excluding any blocks inside the
+        # subgraph.
         for outside in self.exclude_blocks(subgraph):
-            nodes_jump_in_loop = subgraph.intersection(
-                self.out_edges[outside]
-            )
-            headers.update(nodes_jump_in_loop)
-            if nodes_jump_in_loop:
-                entries.add(outside)
+            # Check if the current block points to any blocks that are inside
+            # the subgraph.
+            targets_in_loop = subgraph.intersection(self.out_edges[outside])
+            # Record both headers and entries
+            if targets_in_loop:
+                headers.extend(targets_in_loop)
+                entries.append(outside)
         # If the loop has no headers or entries, the only header is the head of
         # the CFG.
         if not headers:
-            headers = {self.find_head()}
-        return headers, entries
+            headers = headers.append(self.find_head())
+        return sorted(headers), sorted(entries)
 
     def find_exiting_and_exits(
         self, subgraph: Set[BlockName]

--- a/numba_rvsdg/core/transformations.py
+++ b/numba_rvsdg/core/transformations.py
@@ -51,12 +51,12 @@ def loop_restructure_helper(scfg: SCFG, loop: Set[BlockName]):
         solo_head_label = SyntheticHead()
         loop_head: BlockName = insert_block_and_control_blocks(
             scfg,
-            list(sorted(entries)),
-            list(sorted(headers)),
+            entries,
+            headers,
             block_label=solo_head_label)
         loop.add(loop_head)
     else:
-        loop_head: BlockName = next(iter(headers))
+        loop_head: BlockName = headers[0]
     # If there is only a single exiting latch (an exiting block that also has a
     # backedge to the loop header) we can exit early, since the condition for
     # SCFG is fullfilled.
@@ -314,8 +314,8 @@ def extract_region(scfg: SCFG, region_blocks, region_kind):
     exiting_blocks, exit_blocks = scfg.find_exiting_and_exits(region_blocks)
     assert len(headers) == 1
     assert len(exiting_blocks) == 1
-    region_header = next(iter(headers))
-    region_exiting = next(iter(exiting_blocks))
+    region_header = headers[0]
+    region_exiting = exiting_blocks[0]
 
     scfg.add_region(region_header, region_exiting, region_kind)
 


### PR DESCRIPTION
We add some documentation, fixup the typing signature, refactor the function to use return sorted lists, modify some implementation details and add comments to the function. We return sorted lists, because we have been bitten in the past by using sets and them being unordered.