### PR TITLE
Add tracing to simulator tests

### DIFF
--- a/numba_rvsdg/tests/simulator.py
+++ b/numba_rvsdg/tests/simulator.py
@@ -52,7 +52,7 @@ class Simulator:
         Control variable map
     stack: List[Instruction]
         Instruction stack
-    trace: List[Tuple(name, block)]
+    trace: Set[BlockName]
         List of names, block combinations visisted
     branch: Boolean
         Flag to be set during execution.
@@ -71,7 +71,7 @@ class Simulator:
         self.varmap = dict()
         self.ctrl_varmap = dict()
         self.stack = []
-        self.trace = []
+        self.trace = set()
         self.branch = None
         self.return_value = None
 
@@ -137,7 +137,7 @@ class Simulator:
         """
         print("AT", name)
         block = self.get_block(name)
-        self.trace.append((name, block))
+        self.trace.add(name)
 
         if isinstance(block.label, ControlLabel):
             self.run_synth_block(name)

--- a/numba_rvsdg/tests/test_simulate.py
+++ b/numba_rvsdg/tests/test_simulate.py
@@ -100,7 +100,7 @@ class SimulatorTest(unittest.TestCase):
         # loop case
         self._run(foo, flow, {"x": 2})
         # break case
-        self._run(foo, flow, {"x": 15})
+        self._run(foo, flow, {"x": 101})
 
         # check the trace
         self._check_trace(flow)


### PR DESCRIPTION
The simulator based tests now trace the SCFG, and ensure that all test cases will have visited all blocks in the SCFG. This can help during test authoring to ensure full test coverage.