### PR TITLE
Add mockasm to SCFG with a test generator for the restructuring algorithms

### DIFF
--- a/numba_rvsdg/core/datastructures/basic_block.py
+++ b/numba_rvsdg/core/datastructures/basic_block.py
@@ -1,6 +1,6 @@
 import dis
 from collections import ChainMap
-from typing import Tuple, Dict, List
+from typing import Tuple, Dict, List, Set
 from dataclasses import dataclass, field, replace
 
 from numba_rvsdg.core.datastructures.labels import Label
@@ -112,7 +112,7 @@ class BranchBlock(BasicBlock):
 @dataclass(frozen=True)
 class RegionBlock(BasicBlock):
     kind: str = None
-    headers: Dict[Label, BasicBlock] = None
+    headers: Set[Label] = None
     """The header of the region"""
     subregion: "BlockMap" = None
     """The subgraph excluding the headers
@@ -122,8 +122,9 @@ class RegionBlock(BasicBlock):
     """
     def __post_init__(self):
         assert isinstance(self.subregion.graph, dict)
-        assert isinstance(self.headers, dict)
+        assert isinstance(self.headers, set)
 
     def get_full_graph(self):
-        graph = ChainMap(self.subregion.graph, self.headers)
+        # assert not (self.headers - set(self.subregion.graph))
+        graph = self.subregion.graph.copy()
         return graph

--- a/numba_rvsdg/core/datastructures/basic_block.py
+++ b/numba_rvsdg/core/datastructures/basic_block.py
@@ -120,6 +120,9 @@ class RegionBlock(BasicBlock):
     exit: Label = None
     """The exit node.
     """
+    def __post_init__(self):
+        assert isinstance(self.subregion.graph, dict)
+        assert isinstance(self.headers, dict)
 
     def get_full_graph(self):
         graph = ChainMap(self.subregion.graph, self.headers)

--- a/numba_rvsdg/core/datastructures/block_map.py
+++ b/numba_rvsdg/core/datastructures/block_map.py
@@ -315,6 +315,8 @@ class BlockMap:
 
         A closed CFG is a CFG with a unique entry and exit node that have no
         predescessors and no successors respectively.
+
+        Note: This does not fix code entry node that has predescessors.
         """
         # for all nodes that contain a return
         return_nodes = [node for node in self.graph if self.graph[node].is_exiting]
@@ -362,7 +364,7 @@ class BlockMap:
         return BlockMap.from_dict(data)
 
     @staticmethod
-    def from_dict(graph_dict):        
+    def from_dict(graph_dict):
         block_map_graph = {}
         clg = ControlLabelGenerator()
         for index, attributes in graph_dict.items():

--- a/numba_rvsdg/core/transformations.py
+++ b/numba_rvsdg/core/transformations.py
@@ -319,7 +319,7 @@ def extract_region(bbmap, region_blocks, region_kind):
         _jump_targets=bbmap[region_exiting].jump_targets,
         backedges=(),
         kind=region_kind,
-        headers=headers,
+        headers=headers, # XXX: this is the wrong type
         subregion=head_subgraph,
         exit=region_exit,
     )

--- a/numba_rvsdg/tests/mock_asm.py
+++ b/numba_rvsdg/tests/mock_asm.py
@@ -216,11 +216,11 @@ class ProgramGen:
             ]
             [kind] = self.rng.choices(["goto", "brctr", ""], [1, 10, 20])
             if kind == "goto":
-                target = self.rng.randrange(size)
+                target = self.rng.randrange(1, size) # avoid jump back to entry
                 bb.append(f"{indent}goto BB{target}")
             elif kind == "brctr":
-                target0 = self.rng.randrange(size)
-                target1 = self.rng.randrange(size)
+                target0 = self.rng.randrange(1, size) # avoid jump back to entry
+                target1 = self.rng.randrange(1, size) # avoid jump back to entry
                 ctr = self.rng.randrange(1, 10)
                 bb.append(f"{indent}ctr {ctr}")
                 bb.append(f"{indent}brctr BB{target0} BB{target1}")

--- a/numba_rvsdg/tests/test_mock_asm.py
+++ b/numba_rvsdg/tests/test_mock_asm.py
@@ -281,7 +281,7 @@ def to_scfg(instlist: list[Inst]) -> BlockMap:
     return scfg
 
 
-def test_mock_scfg():
+def test_mock_scfg_loop():
     asm = textwrap.dedent("""
             print Start
             goto A
@@ -291,6 +291,41 @@ def test_mock_scfg():
             brctr A B
         label B
             print B
+    """)
+
+    instlist = parse(asm)
+    scfg = to_scfg(instlist)
+
+
+def test_mock_scfg_basic():
+    asm = textwrap.dedent("""
+        label S
+            print Start
+            goto A
+        label A
+            print A
+            ctr 10
+            brctr S B
+        label B
+            print B
+    """)
+
+    instlist = parse(asm)
+    scfg = to_scfg(instlist)
+
+def test_mock_scfg_diamond():
+    asm = textwrap.dedent("""
+            print Start
+            ctr 1
+            brctr A B
+        label A
+            print A
+            goto C
+        label B
+            print B
+            goto C
+        label C
+            print C
     """)
 
     instlist = parse(asm)

--- a/numba_rvsdg/tests/test_mock_asm.py
+++ b/numba_rvsdg/tests/test_mock_asm.py
@@ -1,12 +1,12 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import IntEnum
 from pprint import pprint
 from io import StringIO
-from typing import IO
+from typing import IO, Dict
 import random
 import textwrap
 
-from mock_asm import ProgramGen, parse, VM
+from mock_asm import ProgramGen, parse, VM, Inst, GotoOperands, BrCtrOperands
 
 
 def test_mock_asm():
@@ -73,10 +73,225 @@ def test_program_gen():
 
         instlist = parse(asm)
         with StringIO() as buf:
-            terminated = VM(buf).run(instlist, max_step=1000)
+            terminated = VM(buf).run(instlist,
+                                     max_step=1000)
             got = buf.getvalue().split()
             if terminated:
                 print(asm)
                 print(got)
                 ct_term += 1
     print("terminated", ct_term, "total", total)
+
+from numba_rvsdg.core.datastructures.block_map import BlockMap
+from numba_rvsdg.core.datastructures.labels import Label
+from numba_rvsdg.core.datastructures.basic_block import (
+    BasicBlock,
+    RegionBlock,
+)
+from numba_rvsdg.core.transformations import (
+    restructure_loop,
+    restructure_branch,
+)
+
+
+@dataclass(frozen=True, order=True)
+class MockAsmLabel(Label):
+    pass
+
+@dataclass(frozen=True)
+class MockAsmBasicBlock(BasicBlock):
+    bbinstlist: list[Inst] = field(default_factory=list)
+    bboffset: int = 0
+
+
+
+from numba_rvsdg.core.datastructures.labels import (
+    ControlLabel, ControlLabelGenerator
+)
+from numba_rvsdg.core.datastructures.basic_block import (
+    ControlVariableBlock,
+    BranchBlock,
+)
+# NOTE: modified Renderer to be more general
+class Renderer(object):
+    def __init__(self, bbmap: BlockMap):
+        from graphviz import Digraph
+
+        self.g = Digraph()
+
+        self.rendered_blocks = set()
+
+        # render nodes
+        for label, block in bbmap.graph.items():
+            self.render_block(self.g, label, block)
+        self.render_edges(bbmap.graph)
+
+    def render_basic_block(self, digraph: "Digraph", label: Label, block: BasicBlock):
+        body = str(label)
+        digraph.node(str(label), shape="rect", label=body)
+
+    def render_region_block(
+        self, digraph: "Digraph", label: Label, regionblock: RegionBlock
+    ):
+        # render subgraph
+        graph = regionblock.get_full_graph()
+        with digraph.subgraph(name=f"cluster_{label}") as subg:
+            color = "blue"
+            if regionblock.kind == "branch":
+                color = "green"
+            if regionblock.kind == "tail":
+                color = "purple"
+            if regionblock.kind == "head":
+                color = "red"
+            subg.attr(color=color, label=regionblock.kind)
+            for label, block in graph.items():
+                self.render_block(subg, label, block)
+        # render edges within this region
+        self.render_edges(graph)
+
+    def render_branching_block(
+        self, digraph: "Digraph", label: Label, block: BasicBlock
+    ):
+        if isinstance(label, ControlLabel):
+
+            def find_index(v):
+                if hasattr(v, "offset"):
+                    return v.offset
+                if hasattr(v, "index"):
+                    return v.index
+
+            body = label.__class__.__name__ + ": " + str(label.index) + "\l"
+            body += f"variable: {block.variable}\l"
+            body += "\l".join(
+                (f"{k}=>{find_index(v)}" for k, v in block.branch_value_table.items())
+            )
+        else:
+            raise Exception("Unknown label type: " + label)
+        digraph.node(str(label), shape="rect", label=body)
+
+    def render_block(self, digraph: "Digraph", label: Label, block: BasicBlock):
+        # elif type(block) == PythonBytecodeBlock:
+        #     self.render_basic_block(digraph, label, block)
+        if type(block) == ControlVariableBlock:
+            self.render_control_variable_block(digraph, label, block)
+        elif type(block) == BranchBlock:
+            self.render_branching_block(digraph, label, block)
+        elif type(block) == RegionBlock:
+            self.render_region_block(digraph, label, block)
+        elif isinstance(block, BasicBlock):
+            self.render_basic_block(digraph, label, block)
+        else:
+            raise Exception("unreachable")
+
+
+    def render_edges(self, blocks: Dict[Label, BasicBlock]):
+        for label, block in blocks.items():
+            for dst in block.jump_targets:
+                if dst in blocks:
+                    if type(block) in (
+                        # PythonBytecodeBlock,
+                        MockAsmBasicBlock,
+                        BasicBlock,
+                        ControlVariableBlock,
+                        BranchBlock,
+                    ):
+                        self.g.edge(str(label), str(dst))
+                    elif type(block) == RegionBlock:
+                        if block.exit is not None:
+                            self.g.edge(str(block.exit), str(dst))
+                        else:
+                            self.g.edge(str(label), str(dst))
+                    else:
+                        raise Exception("unreachable")
+            for dst in block.backedges:
+                # assert dst in blocks
+                self.g.edge(
+                    str(label), str(dst), style="dashed", color="grey", constraint="0"
+                )
+    def view(self, *args):
+        self.g.view(*args)
+
+
+
+class MockAsmRenderer(Renderer):
+
+    def render_basic_block(self, digraph: "Digraph", label: Label, block: BasicBlock):
+        block_name = str(label)
+
+        if isinstance(block, MockAsmBasicBlock):
+            end = r"\l"
+            lines = [
+                f"offset: {block.bboffset} | {block_name} ",
+                *[str(inst) for inst in block.bbinstlist],
+            ]
+            body = ''.join([ln + end for ln in lines])
+            digraph.node(str(block_name), shape="rect", label=body)
+        else:
+            super().render_basic_block(digraph, block_name)
+
+
+def to_scfg(instlist: list[Inst]) -> BlockMap:
+    labels = set([0, len(instlist)])
+    for inst in instlist:
+        if isinstance(inst.operands, GotoOperands):
+            labels.add(inst.operands.jump_target)
+        elif isinstance(inst.operands, BrCtrOperands):
+            labels.add(inst.operands.true_target)
+            labels.add(inst.operands.false_target)
+
+    block_map_graph = {}
+    clg = ControlLabelGenerator()
+    scfg = BlockMap(block_map_graph, clg)
+    bb_offsets =sorted(labels)
+    labelmap = {}
+
+
+    for begin, end in zip(bb_offsets, bb_offsets[1:]):
+        labelmap[begin] = label = MockAsmLabel(str(clg.new_index()))
+
+    for begin, end in zip(bb_offsets, bb_offsets[1:]):
+        bb = instlist[begin:end]
+        inst = bb[-1]  # terminator
+        if isinstance(inst.operands, GotoOperands):
+            targets = [inst.operands.jump_target]
+        elif isinstance(inst.operands, BrCtrOperands):
+            targets = [inst.operands.true_target,
+                       inst.operands.false_target]
+        else:
+            targets = []
+
+        label = labelmap[begin]
+        block = MockAsmBasicBlock(
+            label=label,
+            bbinstlist=bb,
+            bboffset=begin,
+            _jump_targets=tuple(labelmap[tgt] for tgt in targets),
+        )
+        scfg.add_block(block)
+
+    # for name, bb in bbmap.items():
+    #     if targets:
+    #         scfg.add_connections(name, [edgemap[tgt] for tgt in targets])
+    # scfg.check_graph()
+
+    scfg.join_returns()
+    restructure_loop(scfg)
+    restructure_branch(scfg)
+    MockAsmRenderer(scfg).view()
+    return scfg
+
+
+def test_mock_scfg():
+    asm = textwrap.dedent("""
+            print Start
+            goto A
+        label A
+            print A
+            ctr 10
+            brctr A B
+        label B
+            print B
+    """)
+
+    instlist = parse(asm)
+    scfg = to_scfg(instlist)

--- a/numba_rvsdg/tests/test_mock_asm.py
+++ b/numba_rvsdg/tests/test_mock_asm.py
@@ -227,7 +227,7 @@ class MockAsmRenderer(Renderer):
             body = ''.join([ln + end for ln in lines])
             digraph.node(str(block_name), shape="rect", label=body)
         else:
-            super().render_basic_block(digraph, block_name)
+            super().render_basic_block(digraph, label, block)
 
 
 def to_scfg(instlist: list[Inst]) -> BlockMap:
@@ -297,10 +297,11 @@ def test_mock_scfg_loop():
     scfg = to_scfg(instlist)
 
 
-def test_mock_scfg_basic():
+def test_mock_scfg_head_cycle():
     asm = textwrap.dedent("""
-        label S
             print Start
+        label S
+            print S
             goto A
         label A
             print A


### PR DESCRIPTION
This is a continuation of #23 merging into main with:

- conversion code from mockasm to SCFG; 
- fuzzing tests that exercise the above with simulation of the raw CFG and restructured SCFG; thus a way to auto-generate tests for the restructuring algorithms.