### PR TITLE
fixup case of backedge from header to header

### DIFF
--- a/numba_rvsdg/core/transformations.py
+++ b/numba_rvsdg/core/transformations.py
@@ -136,7 +136,7 @@ def loop_restructure_helper(scfg: SCFG, loop: Set[str]):
                     # matters in this case.
                     new_jt[new_jt.index(jt)] = synth_assign
                 # If the target is the loop_head
-                elif jt in headers and name not in doms[jt]:
+                elif jt in headers and (name not in doms[jt] or name == jt):
                     # Create the assignment and record it
                     synth_assign = scfg.name_gen.new_block_name(block_names.SYNTH_ASSIGN)
                     new_blocks.add(synth_assign)

--- a/numba_rvsdg/tests/test_transforms.py
+++ b/numba_rvsdg/tests/test_transforms.py
@@ -525,7 +525,7 @@ class TestLoopRestructure(SCFGComparator):
         "0":
             jt: ["1"]
         "1":
-            jt: ["2", "5"]
+            jt: ["5", "2"]
         "2":
             jt: ["6", "7"]
         "3":

--- a/numba_rvsdg/tests/test_transforms.py
+++ b/numba_rvsdg/tests/test_transforms.py
@@ -510,6 +510,41 @@ class TestLoopRestructure(SCFGComparator):
         loop_restructure_helper(original_scfg, set({block_dict["1"], block_dict["2"]}))
         self.assertSCFGEqual(expected_scfg, original_scfg)
 
+    def test_multi_back_edge_with_backedge_from_header(self):
+        original = """
+        "0":
+            jt: ["1"]
+        "1":
+            jt: ["1", "2"]
+        "2":
+            jt: ["1", "3"]
+        "3":
+            jt: []
+        """
+        expected = """
+        "0":
+            jt: ["1"]
+        "1":
+            jt: ["2", "5"]
+        "2":
+            jt: ["6", "7"]
+        "3":
+            jt: []
+        "4":
+            jt: ["1", "3"]
+            be: ["1"]
+        "5":
+            jt: ["4"]
+        "6":
+            jt: ["4"]
+        "7":
+            jt: ["4"]
+        """
+        original_scfg, block_dict = SCFG.from_yaml(original)
+        expected_scfg, _ = SCFG.from_yaml(expected)
+        loop_restructure_helper(original_scfg, set({block_dict["1"], block_dict["2"]}))
+        self.assertSCFGEqual(expected_scfg, original_scfg)
+
     def test_double_exit(self):
         """Loop has two exiting blocks.
 


### PR DESCRIPTION
Fixes #45

Headers of multi-block loops that have a backedge to themselves, didn't have this processed.

The case of:

`label not in doms[jt]`

accounts for the case, where there were multiple entry edges into the loop and the original header has been replaced with a synthetic one.

An alternative fix would have been to simply delete this check, but then this breaks the test case `test_double_header` (after hacking the followup issues). This fix is non-intrusive and a test for the edge cases has been added too.