### PR TITLE
fix missing variable assignment

### DIFF
--- a/numba_rvsdg/core/transformations.py
+++ b/numba_rvsdg/core/transformations.py
@@ -169,7 +169,7 @@ def loop_restructure_helper(scfg: SCFG, loop: Set[str]):
                     variable_assignment[backedge_variable] = reverse_lookup(
                         backedge_value_table, loop_head
                     )
-                    if needs_synth_exit:
+                    if needs_synth_exit or headers_were_unified:
                         variable_assignment[exit_variable] = reverse_lookup(
                             header_value_table, jt
                         )


### PR DESCRIPTION
Fixes #46

The problem was that, in case of a multi-header loop with a single exit, the control-variable wasn't being setup correctly.

A further problem is that, even though this was tested, only the overall block structure of the SCFG was being compared. However the instructions of the blocks themselves were not, so this went unnoticed.

The fix for the test is to add the instructions contained within blocks to the YAML and then we can test this properly.