### PR TITLE
Fix package by enabling auto discovery.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,5 +22,5 @@ dependencies = [
     "pyyaml",
 ]
 
-[tool.setuptools]
-packages = ["numba_rvsdg"]
+[tool.setuptools.packages]
+find = {}


### PR DESCRIPTION
Currently `pip install .` produces an empty package.
This fixes it. I'm just following this page: https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#custom-discovery