### PR TITLE
Test rendering

### DIFF
--- a/numba_rvsdg/core/datastructures/scfg.py
+++ b/numba_rvsdg/core/datastructures/scfg.py
@@ -304,7 +304,7 @@ class SCFG:
             # Need to create synthetic assignments for each arc from a
             # predecessors to a successor and insert it between the predecessor
             # and the newly created block
-            for s in set(jt).intersection(successors):
+            for s in sorted(set(jt).intersection(successors)):
                 synth_assign = self.name_gen.new_block_name(block_names.SYNTH_ASSIGN)
                 variable_assignment = {}
                 variable_assignment[branch_variable] = branch_variable_value

--- a/numba_rvsdg/core/transformations.py
+++ b/numba_rvsdg/core/transformations.py
@@ -102,7 +102,7 @@ def loop_restructure_helper(scfg: SCFG, loop: Set[str]):
     new_blocks = set()
     doms = _doms(scfg)
     # For every block in the loop:
-    for name in loop:
+    for name in sorted(loop):
         # If the block is an exiting block or a backedge block
         if name in exiting_blocks or name in backedge_blocks:
             # Copy the jump targets, these will be modified
@@ -217,7 +217,7 @@ def restructure_loop(scfg: SCFG):
         "restructure_loop found %d loops in %s", len(loops), scfg.graph.keys()
     )
     # rotate and extract loop
-    for loop in loops:
+    for loop in sorted(loops):
         loop_restructure_helper(scfg, loop)
         extract_region(scfg, loop, "loop")
 

--- a/numba_rvsdg/rendering/rendering.py
+++ b/numba_rvsdg/rendering/rendering.py
@@ -37,7 +37,7 @@ class ByteFlowRenderer(object):
             if regionblock.kind == "head":
                 color = "red"
             subg.attr(color=color, label=regionblock.kind)
-            for name, block in graph.items():
+            for name, block in sorted(graph.items()):
                 self.render_block(subg, name, block)
         # render edges within this region
         self.render_edges(graph)
@@ -96,7 +96,7 @@ class ByteFlowRenderer(object):
             raise Exception("unreachable")
 
     def render_edges(self, blocks: Dict[str, BasicBlock]):
-        for name, block in blocks.items():
+        for name, block in sorted(blocks.items()):
             for dst in block.jump_targets:
                 if dst in blocks:
                     if type(block) in (
@@ -135,7 +135,7 @@ class ByteFlowRenderer(object):
 
     def render_scfg(self, scfg):
         # render nodes
-        for name, block in scfg.graph.items():
+        for name, block in sorted(scfg.graph.items()):
             self.render_block(self.g, name, block)
         self.render_edges(scfg.graph)
         return self.g

--- a/numba_rvsdg/tests/test_fig3.py
+++ b/numba_rvsdg/tests/test_fig3.py
@@ -138,7 +138,7 @@ def test_fig3():
     flow = make_flow()
     restructured = flow.restructure()
     dot_output = ByteFlowRenderer().render_byteflow(restructured)
-    assert expected == str(dot_output)
+    assert expected == str(dot_output).strip()
 
 
 if __name__ == "__main__":

--- a/numba_rvsdg/tests/test_fig3.py
+++ b/numba_rvsdg/tests/test_fig3.py
@@ -1,16 +1,117 @@
 # Figure 3 of the paper
+import dis
 from numba_rvsdg.core.datastructures.byte_flow import ByteFlow
 from numba_rvsdg.core.datastructures.flow_info import FlowInfo
-from numba_rvsdg.rendering.rendering import render_flow
+from numba_rvsdg.rendering.rendering import render_flow, ByteFlowRenderer
 
-# import logging
-# logging.basicConfig(level=logging.DEBUG)
+
+expected = """digraph {
+	subgraph cluster_python_bytecode_block_0 {
+		color=red label=head
+		python_bytecode_block_0 [label="python_bytecode_block_0\l  0: OP\l  2: POP_JUMP_IF_TRUE\l" shape=rect]
+	}
+	subgraph cluster_synth_asign_block_0 {
+		color=green label=branch
+		synth_asign_block_0 [label="synth_asign_block_0\lcontrol_var_0 = 0" shape=rect]
+	}
+	subgraph cluster_synth_asign_block_1 {
+		color=green label=branch
+		synth_asign_block_1 [label="synth_asign_block_1\lcontrol_var_0 = 1" shape=rect]
+	}
+	python_bytecode_block_1 -> synth_asign_block_2
+	python_bytecode_block_1 -> synth_asign_block_3
+	synth_asign_block_2 -> synth_tail_block_0
+	synth_asign_block_3 -> synth_tail_block_0
+	python_bytecode_block_3 -> synth_asign_block_4
+	python_bytecode_block_3 -> synth_asign_block_5
+	synth_asign_block_4 -> synth_tail_block_1
+	synth_asign_block_5 -> synth_tail_block_1
+	synth_exit_latch_block_0 -> synth_head_block_0 [color=grey constraint=0 style=dashed]
+	synth_tail_block_0 -> synth_exit_latch_block_0
+	synth_tail_block_1 -> synth_exit_latch_block_0
+	synth_head_block_0 -> python_bytecode_block_1
+	synth_head_block_0 -> python_bytecode_block_3
+	synth_exit_latch_block_0 -> synth_exit_block_0
+	subgraph cluster_synth_head_block_0 {
+		color=purple label=tail
+		subgraph cluster_python_bytecode_block_2 {
+			color=green label=branch
+			python_bytecode_block_2 [label="python_bytecode_block_2\l  8: OP\l 10: JUMP_ABSOLUTE\l" shape=rect]
+		}
+		subgraph cluster_python_bytecode_block_4 {
+			color=green label=branch
+			python_bytecode_block_4 [label="python_bytecode_block_4\l 16: OP\l 18: JUMP_ABSOLUTE\l" shape=rect]
+		}
+		subgraph cluster_python_bytecode_block_5 {
+			color=purple label=tail
+			python_bytecode_block_5 [label="python_bytecode_block_5\l 20: RETURN_VALUE\l" shape=rect]
+		}
+		subgraph cluster_synth_head_block_0 {
+			color=red label=head
+			synth_exit_block_0 [label="synth_exit_block_0\lvariable: control_var_0\l0=>python_bytecode_block_2\l1=>python_bytecode_block_4" shape=rect]
+			subgraph cluster_synth_head_block_0 {
+				color=blue label=loop
+				subgraph cluster_python_bytecode_block_1 {
+					color=green label=branch
+					subgraph cluster_python_bytecode_block_1 {
+						color=red label=head
+						python_bytecode_block_1 [label="python_bytecode_block_1\l  4: OP\l  6: POP_JUMP_IF_TRUE\l" shape=rect]
+					}
+					subgraph cluster_synth_asign_block_2 {
+						color=green label=branch
+						synth_asign_block_2 [label="synth_asign_block_2\lcontrol_var_0 = 0\lbackedge_var_0 = 1" shape=rect]
+					}
+					subgraph cluster_synth_asign_block_3 {
+						color=green label=branch
+						synth_asign_block_3 [label="synth_asign_block_3\lbackedge_var_0 = 0\lcontrol_var_0 = 1" shape=rect]
+					}
+					subgraph cluster_synth_tail_block_0 {
+						color=purple label=tail
+						synth_tail_block_0 [label="synth_tail_block_0\l" shape=rect]
+					}
+				}
+				subgraph cluster_python_bytecode_block_3 {
+					color=green label=branch
+					subgraph cluster_python_bytecode_block_3 {
+						color=red label=head
+						python_bytecode_block_3 [label="python_bytecode_block_3\l 12: OP\l 14: POP_JUMP_IF_TRUE\l" shape=rect]
+					}
+					subgraph cluster_synth_asign_block_4 {
+						color=green label=branch
+						synth_asign_block_4 [label="synth_asign_block_4\lcontrol_var_0 = 1\lbackedge_var_0 = 1" shape=rect]
+					}
+					subgraph cluster_synth_asign_block_5 {
+						color=green label=branch
+						synth_asign_block_5 [label="synth_asign_block_5\lbackedge_var_0 = 0\lcontrol_var_0 = 0" shape=rect]
+					}
+					subgraph cluster_synth_tail_block_1 {
+						color=purple label=tail
+						synth_tail_block_1 [label="synth_tail_block_1\l" shape=rect]
+					}
+				}
+				subgraph cluster_synth_exit_latch_block_0 {
+					color=purple label=tail
+					synth_exit_latch_block_0 [label="synth_exit_latch_block_0\lvariable: backedge_var_0\l0=>synth_head_block_0\l1=>synth_exit_block_0" shape=rect]
+				}
+				subgraph cluster_synth_head_block_0 {
+					color=red label=head
+					synth_head_block_0 [label="synth_head_block_0\lvariable: control_var_0\l0=>python_bytecode_block_1\l1=>python_bytecode_block_3" shape=rect]
+				}
+			}
+		}
+	}
+	python_bytecode_block_2 -> python_bytecode_block_5
+	python_bytecode_block_4 -> python_bytecode_block_5
+	synth_exit_block_0 -> python_bytecode_block_2
+	synth_exit_block_0 -> python_bytecode_block_4
+	python_bytecode_block_0 -> synth_asign_block_0
+	python_bytecode_block_0 -> synth_asign_block_1
+	synth_asign_block_0 -> synth_head_block_0
+	synth_asign_block_1 -> synth_head_block_0
+}"""
 
 
 def make_flow():
-    # flowinfo = FlowInfo()
-    import dis
-
     # fake bytecode just good enough for FlowInfo
     bc = [
         dis.Instruction("OP", 1, None, None, "", 0, None, False),
@@ -34,8 +135,10 @@ def make_flow():
 
 
 def test_fig3():
-    f = make_flow()
-    f.restructure()
+    flow = make_flow()
+    restructured = flow.restructure()
+    dot_output = ByteFlowRenderer().render_byteflow(restructured)
+    assert expected == str(dot_output)
 
 
 if __name__ == "__main__":

--- a/numba_rvsdg/tests/test_fig4.py
+++ b/numba_rvsdg/tests/test_fig4.py
@@ -1,16 +1,77 @@
-# Figure 3 of the paper
+# Figure 4 of the paper
+import dis
 from numba_rvsdg.core.datastructures.byte_flow import ByteFlow
 from numba_rvsdg.core.datastructures.flow_info import FlowInfo
-from numba_rvsdg.rendering.rendering import render_flow
+from numba_rvsdg.rendering.rendering import render_flow, ByteFlowRenderer
 
-# import logging
-# logging.basicConfig(level=logging.DEBUG)
+
+expected = """digraph {
+	subgraph cluster_python_bytecode_block_0 {
+		color=red label=head
+		python_bytecode_block_0 [label="python_bytecode_block_0\l  0: OP\l  2: POP_JUMP_IF_TRUE\l" shape=rect]
+	}
+	python_bytecode_block_2 -> synth_asign_block_1
+	python_bytecode_block_3 -> synth_asign_block_2
+	subgraph cluster_python_bytecode_block_1 {
+		color=green label=branch
+		subgraph cluster_python_bytecode_block_1 {
+			color=red label=head
+			python_bytecode_block_1 [label="python_bytecode_block_1\l  4: OP\l  6: POP_JUMP_IF_TRUE\l" shape=rect]
+		}
+		subgraph cluster_python_bytecode_block_2 {
+			color=green label=branch
+			python_bytecode_block_2 [label="python_bytecode_block_2\l  8: OP\l 10: JUMP_ABSOLUTE\l" shape=rect]
+			synth_asign_block_1 [label="synth_asign_block_1\lcontrol_var_0 = 1" shape=rect]
+		}
+		subgraph cluster_python_bytecode_block_3 {
+			color=green label=branch
+			python_bytecode_block_3 [label="python_bytecode_block_3\l 12: OP\l" shape=rect]
+			synth_asign_block_2 [label="synth_asign_block_2\lcontrol_var_0 = 2" shape=rect]
+		}
+		subgraph cluster_synth_tail_block_0 {
+			color=purple label=tail
+			synth_tail_block_0 [label="synth_tail_block_0\l" shape=rect]
+		}
+	}
+	python_bytecode_block_1 -> python_bytecode_block_2
+	python_bytecode_block_1 -> python_bytecode_block_3
+	synth_asign_block_1 -> synth_tail_block_0
+	synth_asign_block_2 -> synth_tail_block_0
+	subgraph cluster_synth_asign_block_0 {
+		color=green label=branch
+		synth_asign_block_0 [label="synth_asign_block_0\lcontrol_var_0 = 0" shape=rect]
+	}
+	subgraph cluster_synth_head_block_0 {
+		color=purple label=tail
+		subgraph cluster_python_bytecode_block_4 {
+			color=green label=branch
+			python_bytecode_block_4 [label="python_bytecode_block_4\l 14: OP\l 16: JUMP_ABSOLUTE\l" shape=rect]
+		}
+		subgraph cluster_python_bytecode_block_5 {
+			color=purple label=tail
+			python_bytecode_block_5 [label="python_bytecode_block_5\l 18: RETURN_VALUE\l" shape=rect]
+		}
+		subgraph cluster_synth_fill_block_0 {
+			color=green label=branch
+			synth_fill_block_0 [label="synth_fill_block_0\l" shape=rect]
+		}
+		subgraph cluster_synth_head_block_0 {
+			color=red label=head
+			synth_head_block_0 [label="synth_head_block_0\lvariable: control_var_0\l0=>python_bytecode_block_4\l2=>python_bytecode_block_4\l1=>synth_fill_block_0" shape=rect]
+		}
+	}
+	python_bytecode_block_4 -> python_bytecode_block_5
+	synth_fill_block_0 -> python_bytecode_block_5
+	synth_head_block_0 -> python_bytecode_block_4
+	synth_head_block_0 -> synth_fill_block_0
+	python_bytecode_block_0 -> python_bytecode_block_1
+	python_bytecode_block_0 -> synth_asign_block_0
+	synth_tail_block_0 -> synth_head_block_0
+	synth_asign_block_0 -> synth_head_block_0
+}"""
 
 
 def make_flow():
-    # flowinfo = FlowInfo()
-    import dis
-
     # fake bytecode just good enough for FlowInfo
     bc = [
         dis.Instruction("OP", 1, None, None, "", 0, None, False),
@@ -32,8 +93,10 @@ def make_flow():
     return ByteFlow(bc=bc, scfg=scfg)
 
 def test_fig4():
-    f = make_flow()
-    f.restructure()
+    flow = make_flow()
+    restructured = flow.restructure()
+    dot_output = ByteFlowRenderer().render_byteflow(restructured)
+    assert expected == str(dot_output).strip()
 
 
 if __name__ == "__main__":

--- a/numba_rvsdg/tests/test_rendering.py
+++ b/numba_rvsdg/tests/test_rendering.py
@@ -93,4 +93,4 @@ def test_simple():
 	synth_asign_block_0 -> synth_head_block_0
 	synth_asign_block_1 -> synth_head_block_0
 }"""
-    assert expected == str(dot)
+    assert expected == str(dot).strip()

--- a/numba_rvsdg/tests/test_rendering.py
+++ b/numba_rvsdg/tests/test_rendering.py
@@ -1,0 +1,96 @@
+
+from numba_rvsdg.core.datastructures.scfg import SCFG
+from numba_rvsdg.rendering.rendering import ByteFlowRenderer
+
+
+def test_simple():
+    original = """
+    "0":
+        jt: ["1", "2"]
+    "1":
+        jt: ["3"]
+    "2":
+        jt: ["4"]
+    "3":
+        jt: ["2", "5"]
+    "4":
+        jt: ["1"]
+    "5":
+        jt: []
+    """
+    original_scfg, block_dict = SCFG.from_yaml(original)
+    restructured = original_scfg.restructure()
+    dot = ByteFlowRenderer().render_scfg(restructured)
+    expected= """digraph {
+	subgraph cluster_basic_block_0 {
+		color=red label=head
+		basic_block_0 [label="basic_block_0\l" shape=rect]
+	}
+	subgraph cluster_synth_asign_block_0 {
+		color=green label=branch
+		synth_asign_block_0 [label="synth_asign_block_0\lcontrol_var_0 = 0" shape=rect]
+	}
+	subgraph cluster_synth_asign_block_1 {
+		color=green label=branch
+		synth_asign_block_1 [label="synth_asign_block_1\lcontrol_var_0 = 1" shape=rect]
+	}
+	basic_block_1 -> basic_block_3
+	basic_block_3 -> synth_asign_block_2
+	basic_block_3 -> synth_asign_block_3
+	synth_asign_block_2 -> synth_tail_block_0
+	synth_asign_block_3 -> synth_tail_block_0
+	basic_block_2 -> basic_block_4
+	basic_block_4 -> synth_asign_block_4
+	synth_exit_latch_block_0 -> synth_head_block_0 [color=grey constraint=0 style=dashed]
+	synth_tail_block_0 -> synth_exit_latch_block_0
+	synth_asign_block_4 -> synth_exit_latch_block_0
+	synth_head_block_0 -> basic_block_1
+	synth_head_block_0 -> basic_block_2
+	subgraph cluster_synth_head_block_0 {
+		color=purple label=tail
+		basic_block_5 [label="basic_block_5\l" shape=rect]
+		subgraph cluster_synth_head_block_0 {
+			color=blue label=loop
+			subgraph cluster_basic_block_1 {
+				color=green label=branch
+				subgraph cluster_basic_block_1 {
+					color=red label=head
+					basic_block_1 [label="basic_block_1\l" shape=rect]
+					basic_block_3 [label="basic_block_3\l" shape=rect]
+				}
+				subgraph cluster_synth_asign_block_2 {
+					color=green label=branch
+					synth_asign_block_2 [label="synth_asign_block_2\lbackedge_var_0 = 0" shape=rect]
+				}
+				subgraph cluster_synth_asign_block_3 {
+					color=green label=branch
+					synth_asign_block_3 [label="synth_asign_block_3\lbackedge_var_0 = 1" shape=rect]
+				}
+				subgraph cluster_synth_tail_block_0 {
+					color=purple label=tail
+					synth_tail_block_0 [label="synth_tail_block_0\l" shape=rect]
+				}
+			}
+			subgraph cluster_basic_block_2 {
+				color=green label=branch
+				basic_block_2 [label="basic_block_2\l" shape=rect]
+				basic_block_4 [label="basic_block_4\l" shape=rect]
+				synth_asign_block_4 [label="synth_asign_block_4\lbackedge_var_0 = 0" shape=rect]
+			}
+			subgraph cluster_synth_exit_latch_block_0 {
+				color=purple label=tail
+				synth_exit_latch_block_0 [label="synth_exit_latch_block_0\lvariable: backedge_var_0\l0=>synth_head_block_0\l1=>basic_block_5" shape=rect]
+			}
+			subgraph cluster_synth_head_block_0 {
+				color=red label=head
+				synth_head_block_0 [label="synth_head_block_0\lvariable: control_var_0\l0=>basic_block_1\l1=>basic_block_2" shape=rect]
+			}
+		}
+	}
+	synth_exit_latch_block_0 -> basic_block_5
+	basic_block_0 -> synth_asign_block_0
+	basic_block_0 -> synth_asign_block_1
+	synth_asign_block_0 -> synth_head_block_0
+	synth_asign_block_1 -> synth_head_block_0
+}"""
+    assert expected == str(dot)


### PR DESCRIPTION
This PR stabilizes rendering. There are a number of calls to `sorted` both within the algorithms and also within the rendering code that were needed to make this happen. The non-deterministic behaviour is almost always the result of iterating over a set somehere. Many of the tests don't show this, because they just compare the graph structurally. However, comparing `dot` syntax, requires all the node names and their order to be predictable. 

I will comment on each call to `sorted` to discuss where this comes from and why it is needed.