### PR TITLE
Added region hierarchy and unique naming reference for RegionBlocks in SCFGs

### DIFF
--- a/numba_rvsdg/core/datastructures/basic_block.py
+++ b/numba_rvsdg/core/datastructures/basic_block.py
@@ -45,7 +45,7 @@ class BasicBlock:
         """Replaces jump targets of this block by the given tuple.
         The provided jump targets must be in the same order as their
         intended original replacements.
-        
+
         Note that replacing jump targets will not replace the backedge
         tuple, so replacement for any jump targets that is declared as
         a backedge needs to be updated separately using replace_backedges"""
@@ -122,7 +122,7 @@ class SyntheticBranch(SyntheticBlock):
         The provided jump targets must be in the same order as their
         intended original replacements. Additionally also updates the
         branch value table of the branch block.
-        
+
         Note that replacing jump targets will not replace the backedge
         tuple, so replacement for any jump targets that is declared as
         a backedge needs to be updated separately using replace_backedges"""
@@ -169,7 +169,7 @@ class SyntheticExitBranch(SyntheticBranch):
 @dataclass(frozen=True)
 class RegionBlock(BasicBlock):
     kind: str = None
-    """The kind of region. Can be 'head', 'tail', 'branch', 
+    """The kind of region. Can be 'head', 'tail', 'branch',
     'loop' or 'meta' strings"""
     parent_region: "RegionBlock" = None
     """The parent region of this region as per the SCFG."""

--- a/numba_rvsdg/core/datastructures/basic_block.py
+++ b/numba_rvsdg/core/datastructures/basic_block.py
@@ -171,7 +171,7 @@ class RegionBlock(BasicBlock):
     kind: str = None
     """The kind of region. Can be 'head', 'tail', 'branch', 
     'loop' or 'meta' strings"""
-    parent_region: str = None
+    parent_region: "RegionBlock" = None
     """The parent region of this region as per the SCFG."""
     header: str = None
     """The header node of the region"""

--- a/numba_rvsdg/core/datastructures/basic_block.py
+++ b/numba_rvsdg/core/datastructures/basic_block.py
@@ -33,14 +33,29 @@ class BasicBlock:
                 acc.append(j)
         return tuple(acc)
 
-    def replace_backedge(self, target: str) -> "BasicBlock":
+    def declare_backedge(self, target: str) -> "BasicBlock":
+        """Declare one of the jump targets as a backedge of this block.
+        """
         if target in self.jump_targets:
             assert not self.backedges
             return replace(self, backedges=(target,))
         return self
 
     def replace_jump_targets(self, jump_targets: Tuple) -> "BasicBlock":
+        """Replaces jump targets of this block by the given tuple.
+        The provided jump targets must be in the same order as their
+        intended original replacements.
+        
+        Note that replacing jump targets will not replace the backedge
+        tuple, so replacement for any jump targets that is declared as
+        a backedge needs to be updated separately using replace_backedges"""
         return replace(self, _jump_targets=jump_targets)
+
+    def replace_backedges(self, backedges: Tuple) -> "BasicBlock":
+        """Replace back edges of this block by the given tuple.
+        The provided back edges must be in the same order as their
+        intended original replacements."""
+        return replace(self, backedges=backedges)
 
 
 @dataclass(frozen=True)
@@ -103,13 +118,21 @@ class SyntheticBranch(SyntheticBlock):
     branch_value_table: dict = None
 
     def replace_jump_targets(self, jump_targets: Tuple) -> "BasicBlock":
-        fallthrough = len(jump_targets) == 1
+        """Replaces jump targets of this block by the given tuple.
+        The provided jump targets must be in the same order as their
+        intended original replacements. Additionally also updates the
+        branch value table of the branch block.
+        
+        Note that replacing jump targets will not replace the backedge
+        tuple, so replacement for any jump targets that is declared as
+        a backedge needs to be updated separately using replace_backedges"""
+
         old_branch_value_table = self.branch_value_table
         new_branch_value_table = {}
-        for target in self.jump_targets:
+        for target in self._jump_targets:
             if target not in jump_targets:
                 # ASSUMPTION: only one jump_target is being updated
-                diff = set(jump_targets).difference(self.jump_targets)
+                diff = set(jump_targets).difference(self._jump_targets)
                 assert len(diff) == 1
                 new_target = next(iter(diff))
                 for k, v in old_branch_value_table.items():
@@ -146,15 +169,23 @@ class SyntheticExitBranch(SyntheticBranch):
 @dataclass(frozen=True)
 class RegionBlock(BasicBlock):
     kind: str = None
-    headers: Dict[str, BasicBlock] = None
-    """The header of the region"""
+    """The kind of region. Can be 'head', 'tail', 'branch', 
+    'loop' or 'meta' strings"""
+    parent_region: str = None
+    """The parent region of this region as per the SCFG."""
+    header: str = None
+    """The header node of the region"""
     subregion: "SCFG" = None
-    """The subgraph excluding the headers
-    """
+    """The subgraph as an independent SCFG. Note that in case
+    of subregions the exiting node may point to blocks outside
+    of the current SCFG object."""
     exiting: str = None
-    """The exiting node.
-    """
+    """The exiting node of the region."""
 
-    def get_full_graph(self):
-        graph = ChainMap(self.subregion.graph, self.headers)
-        return graph
+    def replace_header(self, new_header):
+        """Does inplace replacement of the header block."""
+        object.__setattr__(self, "header", new_header)
+
+    def replace_exiting(self, new_exiting):
+        """Does, inplace replacement of the exiting block."""
+        object.__setattr__(self, "exiting", new_exiting)

--- a/numba_rvsdg/core/datastructures/byte_flow.py
+++ b/numba_rvsdg/core/datastructures/byte_flow.py
@@ -31,16 +31,16 @@ class ByteFlow:
 
     def _restructure_loop(self):
         scfg = deepcopy(self.scfg)
-        restructure_loop(scfg)
+        restructure_loop(scfg.parent_region)
         for region in _iter_subregions(scfg):
-            restructure_loop(region.subregion)
+            restructure_loop(region)
         return ByteFlow(bc=self.bc, scfg=scfg)
 
     def _restructure_branch(self):
         scfg = deepcopy(self.scfg)
-        restructure_branch(scfg)
+        restructure_branch(scfg.parent_region)
         for region in _iter_subregions(scfg):
-            restructure_branch(region.subregion)
+            restructure_branch(region)
         return ByteFlow(bc=self.bc, scfg=scfg)
 
     def restructure(self):
@@ -48,13 +48,13 @@ class ByteFlow:
         # close
         scfg.join_returns()
         # handle loop
-        restructure_loop(scfg)
+        restructure_loop(scfg.parent_region)
         for region in _iter_subregions(scfg):
-            restructure_loop(region.subregion)
+            restructure_loop(region)
         # handle branch
-        restructure_branch(scfg)
+        restructure_branch(scfg.parent_region)
         for region in _iter_subregions(scfg):
-            restructure_branch(region.subregion)
+            restructure_branch(region)
         return ByteFlow(bc=self.bc, scfg=scfg)
 
 

--- a/numba_rvsdg/core/datastructures/byte_flow.py
+++ b/numba_rvsdg/core/datastructures/byte_flow.py
@@ -31,14 +31,14 @@ class ByteFlow:
 
     def _restructure_loop(self):
         scfg = deepcopy(self.scfg)
-        restructure_loop(scfg.parent_region)
+        restructure_loop(scfg.region)
         for region in _iter_subregions(scfg):
             restructure_loop(region)
         return ByteFlow(bc=self.bc, scfg=scfg)
 
     def _restructure_branch(self):
         scfg = deepcopy(self.scfg)
-        restructure_branch(scfg.parent_region)
+        restructure_branch(scfg.region)
         for region in _iter_subregions(scfg):
             restructure_branch(region)
         return ByteFlow(bc=self.bc, scfg=scfg)
@@ -48,11 +48,11 @@ class ByteFlow:
         # close
         scfg.join_returns()
         # handle loop
-        restructure_loop(scfg.parent_region)
+        restructure_loop(scfg.region)
         for region in _iter_subregions(scfg):
             restructure_loop(region)
         # handle branch
-        restructure_branch(scfg.parent_region)
+        restructure_branch(scfg.region)
         for region in _iter_subregions(scfg):
             restructure_branch(region)
         return ByteFlow(bc=self.bc, scfg=scfg)

--- a/numba_rvsdg/core/datastructures/scfg.py
+++ b/numba_rvsdg/core/datastructures/scfg.py
@@ -70,7 +70,9 @@ class SCFG:
 
     def __post_init__(self):
         name = self.name_gen.new_region_name("meta")
-        new_region = RegionBlock(name = name, kind="meta", header=None, exiting=None, parent_region=None, subregion=self)
+        new_region = RegionBlock(name=name, kind="meta", header=None,
+                                 exiting=None, parent_region=None,
+                                 subregion=self)
         object.__setattr__(self, "region", new_region)
 
     def __getitem__(self, index):
@@ -178,9 +180,12 @@ class SCFG:
         # the CFG.
         if not headers:
             headers = {self.find_head()}
+            # If region is not meta, the current SCFG is contained in a
+            # RegionBlock. The entries to the subgraph are same as entries
+            # to it's parent region block's graph.
             if self.region.kind != "meta":
-                grandparent_region = self.region.parent_region
-                _, entries = grandparent_region.subregion.find_headers_and_entries({self.region.name})
+                parent_region = self.region.parent_region
+                _, entries = parent_region.subregion.find_headers_and_entries({self.region.name})
         return sorted(headers), sorted(entries)
 
     def find_exiting_and_exits(

--- a/numba_rvsdg/core/datastructures/scfg.py
+++ b/numba_rvsdg/core/datastructures/scfg.py
@@ -65,17 +65,13 @@ class SCFG:
         default_factory=NameGenerator, compare=False
     )
 
-    # This is the top-level region
-    parent_region: RegionBlock = field(init=False, compare=False)
-
-    # This is the region storage. It maps region names to the Region objects,
-    # which themselves contain the header and exiting blocks of this region
-    regions: Dict[str, RegionBlock] = field(default_factory=dict, init=False)
+    # This is the top-level region that this SCFG represents.
+    region: RegionBlock = field(init=False, compare=False)
 
     def __post_init__(self):
         name = self.name_gen.new_region_name("meta")
         new_region = RegionBlock(name = name, kind="meta", header=None, exiting=None, parent_region=None, subregion=self)
-        object.__setattr__(self, "parent_region", new_region)
+        object.__setattr__(self, "region", new_region)
 
     def __getitem__(self, index):
         return self.graph[index]
@@ -182,6 +178,9 @@ class SCFG:
         # the CFG.
         if not headers:
             headers = {self.find_head()}
+            if self.region.kind != "meta":
+                grandparent_region = self.region.parent_region
+                _, entries = grandparent_region.subregion.find_headers_and_entries({self.region.name})
         return sorted(headers), sorted(entries)
 
     def find_exiting_and_exits(

--- a/numba_rvsdg/core/datastructures/scfg.py
+++ b/numba_rvsdg/core/datastructures/scfg.py
@@ -437,6 +437,9 @@ class SCFG:
             graph_dict[key] = curr_dict
         return graph_dict
 
+    def view(self, name: str=None):
+        from numba_rvsdg.rendering.rendering import SCFGRenderer
+        SCFGRenderer(self).view(name)
 
 class AbstractGraphView(Mapping):
 

--- a/numba_rvsdg/core/transformations.py
+++ b/numba_rvsdg/core/transformations.py
@@ -309,7 +309,7 @@ def extract_region(scfg: SCFG, region_blocks, region_kind, parent_region: Region
         # Recursively updates the exiting blocks of a regionblock
         region_exiting = region_block.exiting
         region_exiting_block: BasicBlock = region_block.subregion.graph.pop(region_exiting)
-        jt = list(region_exiting_block.jump_targets)
+        jt = list(region_exiting_block._jump_targets)
         for idx, s in enumerate(jt):
             if s is region_header:
                 jt[idx] = region_name

--- a/numba_rvsdg/core/transformations.py
+++ b/numba_rvsdg/core/transformations.py
@@ -53,7 +53,7 @@ def loop_restructure_helper(scfg: SCFG, loop: Set[str]):
     ]
     if (len(backedge_blocks) == 1 and len(exiting_blocks) == 1
         and backedge_blocks[0] == next(iter(exiting_blocks))):
-        scfg.add_block(scfg.graph.pop(backedge_blocks[0]).replace_backedge(loop_head))
+        scfg.add_block(scfg.graph.pop(backedge_blocks[0]).declare_backedge(loop_head))
         return
 
     # The synthetic exiting latch and synthetic exit need to be created
@@ -198,10 +198,11 @@ def loop_restructure_helper(scfg: SCFG, loop: Set[str]):
         scfg.add_block(synth_exit_block)
 
 
-def restructure_loop(scfg: SCFG):
+def restructure_loop(parent_region: RegionBlock):
     """Inplace restructuring of the given graph to extract loops using
     strongly-connected components
     """
+    scfg = parent_region.subregion
     # obtain a List of Sets of names, where all names in each set are strongly
     # connected, i.e. all reachable from one another by traversing the subset
     scc: List[Set[str]] = scfg.compute_scc()
@@ -219,7 +220,7 @@ def restructure_loop(scfg: SCFG):
     # rotate and extract loop
     for loop in loops:
         loop_restructure_helper(scfg, loop)
-        extract_region(scfg, loop, "loop")
+        extract_region(scfg, loop, "loop", parent_region)
 
 
 def find_head_blocks(scfg: SCFG, begin: str) -> Set[str]:
@@ -290,7 +291,7 @@ def find_tail_blocks(
     return tail_subregion
 
 
-def extract_region(scfg, region_blocks, region_kind):
+def extract_region(scfg: SCFG, region_blocks, region_kind, parent_region: RegionBlock):
     headers, entries = scfg.find_headers_and_entries(region_blocks)
     exiting_blocks, exit_blocks = scfg.find_exiting_and_exits(region_blocks)
     assert len(headers) == 1
@@ -298,29 +299,76 @@ def extract_region(scfg, region_blocks, region_kind):
     region_header = next(iter(headers))
     region_exiting = next(iter(exiting_blocks))
 
+    # Generate a new region name
+    region_name = scfg.name_gen.new_region_name(region_kind)
     head_subgraph = SCFG(
         {name: scfg.graph[name] for name in region_blocks}, name_gen=scfg.name_gen
     )
 
-    if isinstance(scfg[region_exiting], RegionBlock):
-        region_exiting = scfg[region_exiting].exiting
-    else:
-        region_exiting = region_exiting
+    def update_exiting(region_block: RegionBlock):
+        # Recursively updates the exiting blocks of a regionblock
+        region_exiting = region_block.exiting
+        region_exiting_block: BasicBlock = region_block.subregion.graph.pop(region_exiting)
+        jt = list(region_exiting_block.jump_targets)
+        for idx, s in enumerate(jt):
+            if s is region_header:
+                jt[idx] = region_name
+        region_exiting_block = region_exiting_block.replace_jump_targets(jump_targets=tuple(jt))
+        be = list(region_exiting_block.backedges)
+        for idx, s in enumerate(be):
+            if s is region_header:
+                be[idx] = region_name
+        region_exiting_block = region_exiting_block.replace_backedges(backedges=tuple(be))
+        if isinstance(region_exiting_block, RegionBlock):
+            region_exiting_block = update_exiting(region_exiting_block)
+        region_block.subregion.add_block(region_exiting_block)
+        return region_block
 
-    subregion = RegionBlock(
-        name=region_header,
-        _jump_targets=scfg[region_exiting].jump_targets,
-        backedges=(),
+    for name in entries:
+        # For all entries, replace the header as a jump target
+        # with the newly created region as a jump target.
+        entry = scfg.graph.pop(name)
+        jt = list(entry._jump_targets)
+        for idx, s in enumerate(jt):
+            if s is region_header:
+                jt[idx] = region_name
+        entry = entry.replace_jump_targets(jump_targets=tuple(jt))
+        be = list(entry.backedges)
+        for idx, s in enumerate(be):
+            if s is region_header:
+                be[idx] = region_name
+        entry = entry.replace_backedges(backedges=tuple(be))
+        # If the entry itself is a region, update it's
+        # exiting blocks too, recursively
+        if isinstance(entry, RegionBlock):
+            entry = update_exiting(entry)
+        scfg.add_block(entry)
+
+    region = RegionBlock(
+        name=region_name,
+        _jump_targets=scfg[region_exiting]._jump_targets,
+        backedges=scfg[region_exiting].backedges,
         kind=region_kind,
-        headers=headers,
+        header=region_header,
         subregion=head_subgraph,
         exiting=region_exiting,
+        parent_region=parent_region.name
     )
     scfg.remove_blocks(region_blocks)
-    scfg.graph[region_header] = subregion
+    scfg.graph[region_name] = region
+    scfg.regions[region_name] = region
+
+    # Set the parent region of the newly generated regional
+    # graph as the current region
+    object.__setattr__(region.subregion, "parent_region", region)
+    if region_header == parent_region.header:
+        parent_region.replace_header(region_name)
+    if region_exiting == parent_region.exiting:
+        parent_region.replace_exiting(region_name)
 
 
-def restructure_branch(scfg: SCFG):
+def restructure_branch(parent_region: RegionBlock):
+    scfg: SCFG = parent_region.subregion
     print("restructure_branch", scfg.graph)
     doms = _doms(scfg)
     postdoms = _post_doms(scfg)
@@ -380,13 +428,13 @@ def restructure_branch(scfg: SCFG):
     )
 
     # extract subregions
-    extract_region(scfg, head_region_blocks, "head")
+    extract_region(scfg, head_region_blocks, "head", parent_region)
     for region in branch_regions:
         if region:
             bra_start, inner_nodes = region
             if inner_nodes:
-                extract_region(scfg, inner_nodes, "branch")
-    extract_region(scfg, tail_region_blocks, "tail")
+                extract_region(scfg, inner_nodes, "branch", parent_region)
+    extract_region(scfg, tail_region_blocks, "tail", parent_region)
 
 
 def _iter_branch_regions(

--- a/numba_rvsdg/core/transformations.py
+++ b/numba_rvsdg/core/transformations.py
@@ -353,8 +353,8 @@ def extract_region(scfg: SCFG, region_blocks, region_kind, parent_region: Region
 
     region = RegionBlock(
         name=region_name,
-        _jump_targets=scfg[region_exiting]._jump_targets,
-        backedges=scfg[region_exiting].backedges,
+        _jump_targets=scfg[region_exiting].jump_targets,
+        backedges=(),
         kind=region_kind,
         header=region_header,
         subregion=head_subgraph,

--- a/numba_rvsdg/core/transformations.py
+++ b/numba_rvsdg/core/transformations.py
@@ -119,8 +119,8 @@ def loop_restructure_helper(scfg: SCFG, loop: Set[str]):
                     # Setup the variables in the assignment table to point to
                     # the correct blocks
                     if needs_synth_exit:
-                        variable_assignment[exit_variable]  = reverse_lookup(exit_value_table, jt)
-                    variable_assignment[backedge_variable]  = reverse_lookup(backedge_value_table,
+                        variable_assignment[exit_variable] = reverse_lookup(exit_value_table, jt)
+                    variable_assignment[backedge_variable] = reverse_lookup(backedge_value_table,
                         synth_exit if needs_synth_exit else next(iter(exit_blocks)))
                     # Create the actual control variable block
                     synth_assign_block = SyntheticAssignment(

--- a/numba_rvsdg/rendering/rendering.py
+++ b/numba_rvsdg/rendering/rendering.py
@@ -154,10 +154,10 @@ class SCFGRenderer(BaseRenderer):
                 color = "purple"
             if regionblock.kind == "head":
                 color = "red"
-            label = regionblock.name  + \
+            label = regionblock.name + \
                 "\njump targets: " + str(regionblock.jump_targets) + \
-                "\nback edges: "  + str(regionblock.backedges)
-                
+                "\nback edges: " + str(regionblock.backedges)
+
             subg.attr(color=color, label=label)
             for name, block in regionblock.subregion.graph.items():
                 self.render_block(subg, name, block)
@@ -165,7 +165,7 @@ class SCFGRenderer(BaseRenderer):
     def render_basic_block(self, digraph: "Digraph", name: str, block: BasicBlock):
         body = name + "\l"+ \
                 "\njump targets: " + str(block.jump_targets) + \
-                "\nback edges: "  + str(block.backedges)
+                "\nback edges: " + str(block.backedges)
 
         digraph.node(str(name), shape="rect", label=body)
 
@@ -196,7 +196,7 @@ class SCFGRenderer(BaseRenderer):
             )
             body += \
                 "\njump targets: " + str(block.jump_targets) + \
-                "\nback edges: "  + str(block.backedges)
+                "\nback edges: " + str(block.backedges)
 
         else:
             raise Exception("Unknown name type: " + name)

--- a/numba_rvsdg/rendering/rendering.py
+++ b/numba_rvsdg/rendering/rendering.py
@@ -111,6 +111,7 @@ class ByteFlowRenderer(object):
                 else:
                     raise Exception("unreachable " + str(src_block))
             for dst_name in src_block.backedges:
+                dst_name = find_base_header(blocks[dst_name]).name
                 if dst_name in blocks.keys():
                     self.g.edge(
                         str(src_block.name), str(dst_name), style="dashed", color="grey", constraint="0"
@@ -235,6 +236,7 @@ class SCFGRenderer:
                 else:
                     raise Exception("unreachable " + str(src_block))
             for dst_name in src_block.backedges:
+                dst_name = find_base_header(blocks[dst_name]).name
                 if dst_name in blocks.keys():
                     self.g.edge(
                         str(src_block.name), str(dst_name), style="dashed", color="grey", constraint="0"

--- a/numba_rvsdg/rendering/rendering.py
+++ b/numba_rvsdg/rendering/rendering.py
@@ -16,8 +16,52 @@ from numba_rvsdg.core.datastructures.byte_flow import ByteFlow
 import dis
 from typing import Dict
 
+class BaseRenderer(object):
+    def render_block(self, digraph: "Digraph", name: str, block: BasicBlock):
+        if type(block) == BasicBlock:
+            self.render_basic_block(digraph, name, block)
+        elif type(block) == PythonBytecodeBlock:
+            self.render_basic_block(digraph, name, block)
+        elif type(block) == SyntheticAssignment:
+            self.render_control_variable_block(digraph, name, block)
+        elif isinstance(block, SyntheticBranch):
+            self.render_branching_block(digraph, name, block)
+        elif isinstance(block, SyntheticBlock):
+            self.render_basic_block(digraph, name, block)
+        elif type(block) == RegionBlock:
+            self.render_region_block(digraph, name, block)
+        else:
+            raise Exception("unreachable")
 
-class ByteFlowRenderer(object):
+    def render_edges(self, scfg: SCFG):
+        blocks = dict(scfg)
+        def find_base_header(block: BasicBlock):
+            if isinstance(block, RegionBlock):
+                block = blocks[block.header]
+                block = find_base_header(block)
+            return block
+
+        for _, src_block in blocks.items():
+            if isinstance(src_block, RegionBlock):
+                continue
+            src_block = find_base_header(src_block)
+            for dst_name in src_block.jump_targets:
+                dst_name = find_base_header(blocks[dst_name]).name
+                if dst_name in blocks.keys():
+                    self.g.edge(str(src_block.name), str(dst_name))
+                else:
+                    raise Exception("unreachable " + str(src_block))
+            for dst_name in src_block.backedges:
+                dst_name = find_base_header(blocks[dst_name]).name
+                if dst_name in blocks.keys():
+                    self.g.edge(
+                        str(src_block.name), str(dst_name), style="dashed", color="grey", constraint="0"
+                    )
+                else:
+                    raise Exception("unreachable " + str(src_block))
+
+
+class ByteFlowRenderer(BaseRenderer):
     def __init__(self):
         from graphviz import Digraph
 
@@ -76,49 +120,6 @@ class ByteFlowRenderer(object):
             raise Exception("Unknown name type: " + name)
         digraph.node(str(name), shape="rect", label=body)
 
-    def render_block(self, digraph: "Digraph", name: str, block: BasicBlock):
-        if type(block) == BasicBlock:
-            self.render_basic_block(digraph, name, block)
-        elif type(block) == PythonBytecodeBlock:
-            self.render_basic_block(digraph, name, block)
-        elif type(block) == SyntheticAssignment:
-            self.render_control_variable_block(digraph, name, block)
-        elif isinstance(block, SyntheticBranch):
-            self.render_branching_block(digraph, name, block)
-        elif isinstance(block, SyntheticBlock):
-            self.render_basic_block(digraph, name, block)
-        elif type(block) == RegionBlock:
-            self.render_region_block(digraph, name, block)
-        else:
-            raise Exception("unreachable")
-
-    def render_edges(self, scfg: SCFG):
-        blocks = dict(scfg)
-        def find_base_header(block: BasicBlock):
-            if isinstance(block, RegionBlock):
-                block = blocks[block.header]
-                block = find_base_header(block)
-            return block
-
-        for _, src_block in blocks.items():
-            if isinstance(src_block, RegionBlock):
-                continue
-            src_block = find_base_header(src_block)
-            for dst_name in src_block.jump_targets:
-                dst_name = find_base_header(blocks[dst_name]).name
-                if dst_name in blocks.keys():
-                    self.g.edge(str(src_block.name), str(dst_name))
-                else:
-                    raise Exception("unreachable " + str(src_block))
-            for dst_name in src_block.backedges:
-                dst_name = find_base_header(blocks[dst_name]).name
-                if dst_name in blocks.keys():
-                    self.g.edge(
-                        str(src_block.name), str(dst_name), style="dashed", color="grey", constraint="0"
-                    )
-                else:
-                    raise Exception("unreachable " + str(src_block))
-
     def render_byteflow(self, byteflow: ByteFlow):
         self.bcmap_from_bytecode(byteflow.bc)
         # render nodes
@@ -131,7 +132,7 @@ class ByteFlowRenderer(object):
         self.bcmap: Dict[int, dis.Instruction] = SCFG.bcmap_from_bytecode(bc)
 
 
-class SCFGRenderer:
+class SCFGRenderer(BaseRenderer):
     def __init__(self, scfg: SCFG):
         from graphviz import Digraph
 
@@ -201,51 +202,9 @@ class SCFGRenderer:
             raise Exception("Unknown name type: " + name)
         digraph.node(str(name), shape="rect", label=body)
 
-    def render_block(self, digraph: "Digraph", name: str, block: BasicBlock):
-        if type(block) == BasicBlock:
-            self.render_basic_block(digraph, name, block)
-        elif type(block) == PythonBytecodeBlock:
-            self.render_basic_block(digraph, name, block)
-        elif type(block) == SyntheticAssignment:
-            self.render_control_variable_block(digraph, name, block)
-        elif isinstance(block, SyntheticBranch):
-            self.render_branching_block(digraph, name, block)
-        elif isinstance(block, SyntheticBlock):
-            self.render_basic_block(digraph, name, block)
-        elif type(block) == RegionBlock:
-            self.render_region_block(digraph, name, block)
-        else:
-            raise Exception("unreachable")
-
-    def render_edges(self, scfg: SCFG):
-        blocks = dict(scfg)
-        def find_base_header(block: BasicBlock):
-            if isinstance(block, RegionBlock):
-                block = blocks[block.header]
-                block = find_base_header(block)
-            return block
-
-        for _, src_block in blocks.items():
-            if isinstance(src_block, RegionBlock):
-                continue
-            src_block = find_base_header(src_block)
-            for dst_name in src_block.jump_targets:
-                dst_name = find_base_header(blocks[dst_name]).name
-                if dst_name in blocks.keys():
-                    self.g.edge(str(src_block.name), str(dst_name))
-                else:
-                    raise Exception("unreachable " + str(src_block))
-            for dst_name in src_block.backedges:
-                dst_name = find_base_header(blocks[dst_name]).name
-                if dst_name in blocks.keys():
-                    self.g.edge(
-                        str(src_block.name), str(dst_name), style="dashed", color="grey", constraint="0"
-                    )
-                else:
-                    raise Exception("unreachable " + str(src_block))
-
     def view(self, name: str):
         self.g.view(name)
+
 
 logging.basicConfig(level=logging.DEBUG)
 

--- a/numba_rvsdg/rendering/rendering.py
+++ b/numba_rvsdg/rendering/rendering.py
@@ -126,16 +126,124 @@ class ByteFlowRenderer(object):
         self.render_edges(byteflow.scfg)
         return self.g
 
-    def render_scfg(self, scfg):
+    def bcmap_from_bytecode(self, bc: dis.Bytecode):
+        self.bcmap: Dict[int, dis.Instruction] = SCFG.bcmap_from_bytecode(bc)
+
+
+class SCFGRenderer:
+    def __init__(self, scfg: SCFG):
+        from graphviz import Digraph
+
+        self.g = Digraph()
         # render nodes
         for name, block in scfg.graph.items():
             self.render_block(self.g, name, block)
         self.render_edges(scfg)
-        return self.g
 
-    def bcmap_from_bytecode(self, bc: dis.Bytecode):
-        self.bcmap: Dict[int, dis.Instruction] = SCFG.bcmap_from_bytecode(bc)
+    def render_region_block(
+        self, digraph: "Digraph", name: str, regionblock: RegionBlock
+    ):
+        # render subgraph
+        with digraph.subgraph(name=f"cluster_{name}") as subg:
+            color = "blue"
+            if regionblock.kind == "branch":
+                color = "green"
+            if regionblock.kind == "tail":
+                color = "purple"
+            if regionblock.kind == "head":
+                color = "red"
+            label = regionblock.name  + \
+                "\njump targets: " + str(regionblock.jump_targets) + \
+                "\nback edges: "  + str(regionblock.backedges)
+                
+            subg.attr(color=color, label=label)
+            for name, block in regionblock.subregion.graph.items():
+                self.render_block(subg, name, block)
 
+    def render_basic_block(self, digraph: "Digraph", name: str, block: BasicBlock):
+        body = name + "\l"+ \
+                "\njump targets: " + str(block.jump_targets) + \
+                "\nback edges: "  + str(block.backedges)
+
+        digraph.node(str(name), shape="rect", label=body)
+
+    def render_control_variable_block(
+        self, digraph: "Digraph", name: str, block: BasicBlock
+    ):
+        if isinstance(name, str):
+            body = name + "\l"
+            body += "\l".join(
+                (f"{k} = {v}" for k, v in block.variable_assignment.items())
+            )
+            body +=  \
+                "\njump targets: " + str(block.jump_targets) + \
+                "\nback edges: "  + str(block.backedges)
+
+        else:
+            raise Exception("Unknown name type: " + name)
+        digraph.node(str(name), shape="rect", label=body)
+
+    def render_branching_block(
+        self, digraph: "Digraph", name: str, block: BasicBlock
+    ):
+        if isinstance(name, str):
+            body = name + "\l"
+            body += f"variable: {block.variable}\l"
+            body += "\l".join(
+                (f"{k}=>{v}" for k, v in block.branch_value_table.items())
+            )
+            body += \
+                "\njump targets: " + str(block.jump_targets) + \
+                "\nback edges: "  + str(block.backedges)
+
+        else:
+            raise Exception("Unknown name type: " + name)
+        digraph.node(str(name), shape="rect", label=body)
+
+    def render_block(self, digraph: "Digraph", name: str, block: BasicBlock):
+        if type(block) == BasicBlock:
+            self.render_basic_block(digraph, name, block)
+        elif type(block) == PythonBytecodeBlock:
+            self.render_basic_block(digraph, name, block)
+        elif type(block) == SyntheticAssignment:
+            self.render_control_variable_block(digraph, name, block)
+        elif isinstance(block, SyntheticBranch):
+            self.render_branching_block(digraph, name, block)
+        elif isinstance(block, SyntheticBlock):
+            self.render_basic_block(digraph, name, block)
+        elif type(block) == RegionBlock:
+            self.render_region_block(digraph, name, block)
+        else:
+            raise Exception("unreachable")
+
+    def render_edges(self, scfg: SCFG):
+        blocks = dict(scfg)
+        def find_base_header(block: BasicBlock):
+            if isinstance(block, RegionBlock):
+                block = blocks[block.header]
+                block = find_base_header(block)
+            return block
+
+        for _, src_block in blocks.items():
+            if isinstance(src_block, RegionBlock):
+                continue
+            src_block = find_base_header(src_block)
+            for dst_name in src_block.jump_targets:
+                dst_name = find_base_header(blocks[dst_name]).name
+                if dst_name in blocks.keys():
+                    self.g.edge(str(src_block.name), str(dst_name))
+                else:
+                    raise Exception("unreachable " + str(src_block))
+            for dst_name in src_block.backedges:
+                if dst_name in blocks.keys():
+                    self.g.edge(
+                        str(src_block.name), str(dst_name), style="dashed", color="grey", constraint="0"
+                    )
+                else:
+                    raise Exception("unreachable " + str(src_block))
+
+    def view(self, name: str):
+        self.g.view(name)
 
 logging.basicConfig(level=logging.DEBUG)
 

--- a/numba_rvsdg/tests/simulator.py
+++ b/numba_rvsdg/tests/simulator.py
@@ -180,6 +180,10 @@ class Simulator:
         region: RegionBlock = self.get_block(name)
         self.region_stack.append(region)
         while True:
+            # If the given name is of the same region,
+            # we execute it's first block, i.e. head
+            if name == region.name:
+                name = region.subregion.find_head()
             # Execute the first block of the region.
             action = self.run_BasicBlock(name)
             # If we need to return, break and do so

--- a/numba_rvsdg/tests/simulator.py
+++ b/numba_rvsdg/tests/simulator.py
@@ -201,7 +201,7 @@ class Simulator:
         # Pop the region from the region stack again and return the final
         # action for this region
         popped = self.region_stack.pop()
-        assert(popped == region)
+        assert (popped == region)
         return action
 
     def run_PythonBytecodeBlock(self, name: str):

--- a/numba_rvsdg/tests/test_scc.py
+++ b/numba_rvsdg/tests/test_scc.py
@@ -1,0 +1,54 @@
+from numba_rvsdg.core.datastructures.byte_flow import ByteFlow
+from numba_rvsdg.rendering.rendering import render_flow
+
+def scc(G):
+    preorder = {}
+    lowlink = {}
+    scc_found = set()
+    scc_queue = []
+    out = []
+    i = 0  # Preorder counter
+    for source in G:
+        if source not in scc_found:
+            queue = [source]
+            while queue:
+                v = queue[-1]
+                if v not in preorder:
+                    i = i + 1
+                    preorder[v] = i
+                done = True
+                for w in G[v]:
+                    if w not in preorder:
+                        queue.append(w)
+                        done = False
+                        break
+                if done:
+                    lowlink[v] = preorder[v]
+                    for w in G[v]:
+                        if w not in scc_found:
+                            if preorder[w] > preorder[v]:
+                                lowlink[v] = min([lowlink[v], lowlink[w]])
+                            else:
+                                lowlink[v] = min([lowlink[v], preorder[w]])
+                    queue.pop()
+                    if lowlink[v] == preorder[v]:
+                        scc = {v}
+                        while scc_queue and preorder[scc_queue[-1]] > preorder[v]:
+                            k = scc_queue.pop()
+                            scc.add(k)
+                        scc_found.update(scc)
+                        out.append(scc)
+                    else:
+                        scc_queue.append(v)
+    return out
+
+
+def make_flow(func):
+    return ByteFlow.from_bytecode(func)
+
+def test_scc():
+    f = make_flow(scc)
+    f.restructure()
+
+if __name__ == "__main__":
+    render_flow(make_flow(scc))

--- a/numba_rvsdg/tests/test_scfg.py
+++ b/numba_rvsdg/tests/test_scfg.py
@@ -143,7 +143,7 @@ class TestConcealedRegionView(TestCase):
         flow = ByteFlow.from_bytecode(self.foo)
         restructured = flow._restructure_loop()
         expected = [('python_bytecode_block_0', PythonBytecodeBlock),
-                    ('python_bytecode_block_1', RegionBlock),
+                    ('loop_region_0', RegionBlock),
                     ('python_bytecode_block_3', PythonBytecodeBlock)]
         received = list(((k, type(v)) for k,v in restructured.scfg.concealed_region_view.items()))
         self.assertEqual(expected, received)

--- a/numba_rvsdg/tests/test_scfg.py
+++ b/numba_rvsdg/tests/test_scfg.py
@@ -145,7 +145,7 @@ class TestConcealedRegionView(TestCase):
         expected = [('python_bytecode_block_0', PythonBytecodeBlock),
                     ('loop_region_0', RegionBlock),
                     ('python_bytecode_block_3', PythonBytecodeBlock)]
-        received = list(((k, type(v)) for k,v in restructured.scfg.concealed_region_view.items()))
+        received = list(((k, type(v)) for k, v in restructured.scfg.concealed_region_view.items()))
         self.assertEqual(expected, received)
 
 

--- a/numba_rvsdg/tests/test_transforms.py
+++ b/numba_rvsdg/tests/test_transforms.py
@@ -447,7 +447,7 @@ class TestLoopRestructure(SCFGComparator):
 
     def test_no_op(self):
         """Loop consists of two blocks, but it's in form."""
-        original ="""
+        original = """
         "0":
             jt: ["1"]
         "1":
@@ -457,7 +457,7 @@ class TestLoopRestructure(SCFGComparator):
         "3":
             jt: []
         """
-        expected ="""
+        expected = """
         "0":
             jt: ["1"]
         "1":

--- a/numba_rvsdg/tests/test_transforms.py
+++ b/numba_rvsdg/tests/test_transforms.py
@@ -2,7 +2,7 @@
 from unittest import main
 
 from numba_rvsdg.core.datastructures.scfg import SCFG
-from numba_rvsdg.core.datastructures.basic_block import BasicBlock
+from numba_rvsdg.core.datastructures.basic_block import BasicBlock, RegionBlock
 from numba_rvsdg.core.transformations import loop_restructure_helper
 from numba_rvsdg.tests.test_utils import SCFGComparator
 from numba_rvsdg.core.datastructures import block_names


### PR DESCRIPTION
As titled,

This PR makes the following major changes:

- It adds a region hierarchy by the use of `SCFG.parent_region` and `SCFG.regions`
- For any SCFG that we create independently, a 'meta-region' is generated automatically which can be used to refer to the graph as a whole. 
- During transformations like `loop_restructuring` and `branch_restructuring` every new region created has itself declared as the `parent_region` in the corresponding subregion SCFG.
- `loop_restructuring` and `branch_restructuring` now take regions (`RegionBlock`) as arguments instead of graphs (`SCFG`s). To do the transformation on an entire graph, we can simply provide the `meta-region` of the graph instead.
- `RegionBlock`s are now referred to using their own independent names. They are no longer referred using the header block's name. Hence `RegionBlock`s can now be treated as essentially independent blocks. 
- `SCFG`s now have a `.view()` method that renders a quick preview of the current state of the SCFG. (assuming it's valid)

Note that currently `RegionBlock`s share jump targets with their corresponding `exiting` blocks. Hence any updates made to jump targets of a `RegionBlock`, need to be made recursively to their corresponding exiting blocks as well. 