### PR TITLE
fix insert_SyntheticFill

### DIFF
--- a/numba_rvsdg/core/datastructures/scfg.py
+++ b/numba_rvsdg/core/datastructures/scfg.py
@@ -14,6 +14,7 @@ from numba_rvsdg.core.datastructures.basic_block import (
     SyntheticExit,
     SyntheticTail,
     SyntheticReturn,
+    SyntheticFill,
     RegionBlock,
 )
 from numba_rvsdg.core.datastructures import block_names
@@ -283,7 +284,7 @@ class SCFG:
     def insert_SyntheticFill(
         self, new_name: str, predecessors: Set[str], successors: Set[str],
     ):
-        self._insert_block(new_name, predecessors, successors, SyntheticReturn)
+        self._insert_block(new_name, predecessors, successors, SyntheticFill)
 
     def insert_block_and_control_blocks(
         self, new_name: str, predecessors: Set[str], successors: Set[str]

--- a/numba_rvsdg/tests/simulator.py
+++ b/numba_rvsdg/tests/simulator.py
@@ -272,6 +272,9 @@ class Simulator:
     def synth_SyntheticReturn(self, control_name, block):
         pass
 
+    def synth_SyntheticFill(self, control_name, block):
+        pass
+
     def synth_SyntheticBlock(self, control_name, block):
         raise NotImplementedError("SyntheticBlock should not be instantiated")
 


### PR DESCRIPTION
The `insert_SyntheticFill` method was returning a `SyntheticReturn`, rather than a `SyntheticFill`, which does exist.

This fixes that method and adds support for `SyntheticFill` to the simulator for testing purposes.