### PR TITLE
Patching debug logging calls and debug print statements

### DIFF
--- a/numba_rvsdg/core/datastructures/byte_flow.py
+++ b/numba_rvsdg/core/datastructures/byte_flow.py
@@ -5,7 +5,8 @@ from dataclasses import dataclass
 from numba_rvsdg.core.datastructures.scfg import SCFG
 from numba_rvsdg.core.datastructures.basic_block import RegionBlock
 from numba_rvsdg.core.datastructures.flow_info import FlowInfo
-from numba_rvsdg.core.utils import _logger, _LogWrap
+
+# from numba_rvsdg.core.utils import _logger, _LogWrap
 
 from numba_rvsdg.core.transformations import (
     restructure_loop,
@@ -54,7 +55,7 @@ class ByteFlow:
             The resulting ByteFlow object.
         """
         bc = dis.Bytecode(code)
-        _logger.debug("Bytecode\n%s", _LogWrap(lambda: bc.dis()))
+        # _logger.debug("Bytecode\n%s", _LogWrap(lambda: bc.dis()))
 
         flowinfo = FlowInfo.from_bytecode(bc)
         scfg = flowinfo.build_basicblocks()

--- a/numba_rvsdg/core/transformations.py
+++ b/numba_rvsdg/core/transformations.py
@@ -11,7 +11,7 @@ from numba_rvsdg.core.datastructures.basic_block import (
 )
 from numba_rvsdg.core.datastructures import block_names
 
-from numba_rvsdg.core.utils import _logger
+# from numba_rvsdg.core.utils import _logger
 
 
 def loop_restructure_helper(scfg: SCFG, loop: Set[str]):
@@ -250,9 +250,11 @@ def restructure_loop(parent_region: RegionBlock):
         or next(iter(nodes)) in scfg[next(iter(nodes))].jump_targets
     ]
 
-    _logger.debug(
-        "restructure_loop found %d loops in %s", len(loops), scfg.graph.keys()
-    )
+    # _logger.debug(
+    #     "restructure_loop found %d loops in %s",
+    #     len(loops),
+    #     scfg.graph.keys()
+    # )
     # rotate and extract loop
     for loop in loops:
         loop_restructure_helper(scfg, loop)

--- a/numba_rvsdg/core/transformations.py
+++ b/numba_rvsdg/core/transformations.py
@@ -431,7 +431,7 @@ def extract_region(
 
 def restructure_branch(parent_region: RegionBlock):
     scfg: SCFG = parent_region.subregion
-    print("restructure_branch", scfg.graph)
+    # print("restructure_branch", scfg.graph)
     doms = _doms(scfg)
     postdoms = _post_doms(scfg)
     postimmdoms = _imm_doms(postdoms)

--- a/numba_rvsdg/core/utils.py
+++ b/numba_rvsdg/core/utils.py
@@ -1,6 +1,6 @@
-import logging
+# import logging
 
-_logger = logging.getLogger(__name__)
+# _logger = logging.getLogger(__name__)
 
 
 class _LogWrap:

--- a/numba_rvsdg/rendering/rendering.py
+++ b/numba_rvsdg/rendering/rendering.py
@@ -1,4 +1,4 @@
-import logging
+# import logging
 from numba_rvsdg.core.datastructures.basic_block import (
     BasicBlock,
     RegionBlock,
@@ -50,8 +50,10 @@ class BaseRenderer:
             self.render_basic_block(digraph, name, block)
         elif type(block) == RegionBlock:
             self.render_region_block(digraph, name, block)
+        elif isinstance(block, BasicBlock):
+            self.render_basic_block(digraph, name, block)
         else:
-            raise Exception("unreachable")
+            raise Exception(f"unreachable: {type(block)}")
 
     def render_edges(self, scfg: SCFG):
         """Function that renders the edges in an SCFG.
@@ -169,8 +171,7 @@ class ByteFlowRenderer(BaseRenderer):
         digraph.node(str(name), shape="rect", label=body)
 
     def render_byteflow(self, byteflow: ByteFlow):
-        """Renders the provided `ByteFlow` object.
-        """
+        """Renders the provided `ByteFlow` object."""
         self.bcmap_from_bytecode(byteflow.bc)
         # render nodes
         for name, block in byteflow.scfg.graph.items():
@@ -292,7 +293,7 @@ class SCFGRenderer(BaseRenderer):
         self.g.view(name)
 
 
-logging.basicConfig(level=logging.DEBUG)
+# logging.basicConfig(level=logging.DEBUG)
 
 
 def render_func(func):


### PR DESCRIPTION
As titled,

This PR patches all calls to `logging.basicConfig` and orphan `print` statements used for debugging purposes.