### PR TITLE
updates to the conda-recipe using grayskull

### DIFF
--- a/conda-recipes/bld.bat
+++ b/conda-recipes/bld.bat
@@ -1,2 +1,0 @@
-%PYTHON% -m pip install .
-if errorlevel 1 exit 1

--- a/conda-recipes/build.sh
+++ b/conda-recipes/build.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-set -x
-$PYTHON -m pip install .

--- a/conda-recipes/meta.yaml
+++ b/conda-recipes/meta.yaml
@@ -10,12 +10,16 @@ source:
   path: ../
 
 build:
-  number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
-  
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+  string: {{ GIT_BUILD_STR }}
+
 requirements:
-  build:
-    - python
+  host:
+    - python >=3.11
     - setuptools
+    - pip
   run:
     - python >=3.11
     - python-graphviz
@@ -28,6 +32,7 @@ test:
     - pytest --pyargs numba_rvsdg
 
 about:
+  summary: Numba Compatible RVSDG utilities
   home: https://github.com/numba/numba_rvsdg
   license: Simplified BSD License
-  summary: TBD
+  license_file: LICENSE


### PR DESCRIPTION
This updates the `conda` recipe using out from the `grayskull` tool:

https://github.com/conda/grayskull

The basic procedure was to first generate an `sdist` using:

`pipx run build --sdist` 

.. as suggested by `.github/workflows/release.yml`.

This resulted in the follwing:

```
 💣 zsh» cat numba_rvsdg/meta.yaml                                                                                                                                      :(
{% set name = "numba_rvsdg" %}
{% set version = "0.0.2" %}

package:
  name: {{ name|lower }}
  version: {{ version }}

source:
  url: file:///Users/vhaenel/git/numba-rvsdg/dist/numba_rvsdg-0.0.2.tar.gz
  sha256: e2f905ad1cd5f0ca1f5fad02c42519111b1fc4cf189f5a0e3a3c293509d60b76

build:
  noarch: python
  script: {{ PYTHON }} -m pip install . -vv
  number: 0

requirements:
  host:
    - python >=3.11
    - setuptools
    - pip
  run:
    - python >=3.11
    - python-graphviz
    - pyyaml

test:
  imports:
    - numba_rvsdg
  commands:
    - pip check
  requires:
    - pip

about:
  summary: Numba Compatible RVSDG utilities
  license: BSD-2-Clause
  license_file: LICENSE

extra:
  recipe-maintainers:
    - esc
```

I then took the most important things, which were how to build a `noarch` package and using the `script` directive and spliced them into the current recipe in `conda-recipes/meta.yaml`.

I then also updated the `build/string` attribute.

Here is a log:

```
 💣 zsh» conda build conda-recipes/
WARNING: No numpy version specified in conda_build_config.yaml.  Falling back to default numpy value of 1.22
Copying /Users/esc/git/numba-rvsdg to /Users/esc/miniconda3-arm64/conda-bld/numba_rvsdg_1691595069250/work/
Adding in variants from internal_defaults
Attempting to finalize metadata for numba_rvsdg
Collecting package metadata (repodata.json): ...working... done
Solving environment: ...working... done
Collecting package metadata (repodata.json): ...working... done
Solving environment: ...working... done
BUILD START: ['numba_rvsdg-0.0.2-46_gac7f5dfa83.tar.bz2']
Collecting package metadata (repodata.json): ...working... done
Solving environment: ...working... done

## Package Plan ##

  environment location: /Users/esc/miniconda3-arm64/conda-bld/numba_rvsdg_1691595069250/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_


The following NEW packages will be INSTALLED:

    bzip2:           1.0.8-h620ffc9_4       defaults
    ca-certificates: 2023.05.30-hca03da5_0  defaults
    libffi:          3.4.4-hca03da5_0       defaults
    ncurses:         6.4-h313beb8_0         defaults
    openssl:         3.0.10-h1a28f6b_0      defaults
    pip:             23.2.1-py311hca03da5_0 defaults
    python:          3.11.4-hb885b13_0      defaults
    readline:        8.2-h1a28f6b_0         defaults
    setuptools:      68.0.0-py311hca03da5_0 defaults
    sqlite:          3.41.2-h80987f9_0      defaults
    tk:              8.6.12-hb8d0fd4_0      defaults
    tzdata:          2023c-h04d1e81_0       defaults
    wheel:           0.38.4-py311hca03da5_0 defaults
    xz:              5.4.2-h80987f9_0       defaults
    zlib:            1.2.13-h5a0b063_0      defaults

Preparing transaction: ...working... done
Verifying transaction: ...working... done
Executing transaction: ...working... done
Collecting package metadata (repodata.json): ...working... done
Solving environment: ...working... done
source tree in: /Users/esc/miniconda3-arm64/conda-bld/numba_rvsdg_1691595069250/work
export PREFIX=/Users/esc/miniconda3-arm64/conda-bld/numba_rvsdg_1691595069250/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_
export BUILD_PREFIX=/Users/esc/miniconda3-arm64/conda-bld/numba_rvsdg_1691595069250/_build_env
export SRC_DIR=/Users/esc/miniconda3-arm64/conda-bld/numba_rvsdg_1691595069250/work
Using pip 23.2.1 from $PREFIX/lib/python3.11/site-packages/pip (python 3.11)
Non-user install because user site-packages disabled
Ignoring indexes: https://pypi.org/simple
Created temporary directory: /private/tmp/pip-build-tracker-a_8tii3x
Initialized build tracking at /private/tmp/pip-build-tracker-a_8tii3x
Created build tracker: /private/tmp/pip-build-tracker-a_8tii3x
Entered build tracker: /private/tmp/pip-build-tracker-a_8tii3x
Created temporary directory: /private/tmp/pip-install-cwlscw9j
Created temporary directory: /private/tmp/pip-ephem-wheel-cache-9l6cz7ti
Processing $SRC_DIR
  Added file://$SRC_DIR to build tracker '/private/tmp/pip-build-tracker-a_8tii3x'
  Created temporary directory: /private/tmp/pip-modern-metadata-955pc2z5
  Preparing metadata (pyproject.toml): started
  Running command Preparing metadata (pyproject.toml)
  /Users/esc/miniconda3-arm64/conda-bld/numba_rvsdg_1691595069250/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_/lib/python3.11/site-packages/setuptools/config/pyprojecttoml.py:66: _BetaConfiguration: Support for `[tool.setuptools]` in `pyproject.toml` is still *beta*.
    config = read_configuration(filepath, True, ignore_option_errors, dist)
  running dist_info
  creating /private/tmp/pip-modern-metadata-955pc2z5/numba_rvsdg.egg-info
  writing /private/tmp/pip-modern-metadata-955pc2z5/numba_rvsdg.egg-info/PKG-INFO
  writing dependency_links to /private/tmp/pip-modern-metadata-955pc2z5/numba_rvsdg.egg-info/dependency_links.txt
  writing requirements to /private/tmp/pip-modern-metadata-955pc2z5/numba_rvsdg.egg-info/requires.txt
  writing top-level names to /private/tmp/pip-modern-metadata-955pc2z5/numba_rvsdg.egg-info/top_level.txt
  writing manifest file '/private/tmp/pip-modern-metadata-955pc2z5/numba_rvsdg.egg-info/SOURCES.txt'
  reading manifest file '/private/tmp/pip-modern-metadata-955pc2z5/numba_rvsdg.egg-info/SOURCES.txt'
  adding license file 'LICENSE'
  writing manifest file '/private/tmp/pip-modern-metadata-955pc2z5/numba_rvsdg.egg-info/SOURCES.txt'
  creating '/private/tmp/pip-modern-metadata-955pc2z5/numba_rvsdg-0.0.2.dist-info'
  Preparing metadata (pyproject.toml): finished with status 'done'
  Source in $SRC_DIR has version 0.0.2, which satisfies requirement numba-rvsdg==0.0.2 from file://$SRC_DIR
  Removed numba-rvsdg==0.0.2 from file://$SRC_DIR from build tracker '/private/tmp/pip-build-tracker-a_8tii3x'
Created temporary directory: /private/tmp/pip-unpack-fhjjg19i
Building wheels for collected packages: numba-rvsdg
  Created temporary directory: /private/tmp/pip-wheel-0xd9jcwe
  Destination directory: /private/tmp/pip-wheel-0xd9jcwe
  Building wheel for numba-rvsdg (pyproject.toml): started
  Running command Building wheel for numba-rvsdg (pyproject.toml)
  /Users/esc/miniconda3-arm64/conda-bld/numba_rvsdg_1691595069250/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_/lib/python3.11/site-packages/setuptools/config/pyprojecttoml.py:66: _BetaConfiguration: Support for `[tool.setuptools]` in `pyproject.toml` is still *beta*.
    config = read_configuration(filepath, True, ignore_option_errors, dist)
  running bdist_wheel
  running build
  running build_py
  creating build
  creating build/lib
  creating build/lib/numba_rvsdg
  copying numba_rvsdg/__init__.py -> build/lib/numba_rvsdg
  running egg_info
  writing numba_rvsdg.egg-info/PKG-INFO
  writing dependency_links to numba_rvsdg.egg-info/dependency_links.txt
  writing requirements to numba_rvsdg.egg-info/requires.txt
  writing top-level names to numba_rvsdg.egg-info/top_level.txt
  reading manifest file 'numba_rvsdg.egg-info/SOURCES.txt'
  adding license file 'LICENSE'
  writing manifest file 'numba_rvsdg.egg-info/SOURCES.txt'
  /Users/esc/miniconda3-arm64/conda-bld/numba_rvsdg_1691595069250/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_/lib/python3.11/site-packages/setuptools/command/build_py.py:201: _Warning: Package 'numba_rvsdg.core' is absent from the `packages` configuration.
  !!

          ********************************************************************************
          ############################
          # Package would be ignored #
          ############################
          Python recognizes 'numba_rvsdg.core' as an importable package[^1],
          but it is absent from setuptools' `packages` configuration.

          This leads to an ambiguous overall configuration. If you want to distribute this
          package, please make sure that 'numba_rvsdg.core' is explicitly added
          to the `packages` configuration field.

          Alternatively, you can also rely on setuptools' discovery methods
          (for example by using `find_namespace_packages(...)`/`find_namespace:`
          instead of `find_packages(...)`/`find:`).

          You can read more about "package discovery" on setuptools documentation page:

          - https://setuptools.pypa.io/en/latest/userguide/package_discovery.html

          If you don't want 'numba_rvsdg.core' to be distributed and are
          already explicitly excluding 'numba_rvsdg.core' via
          `find_namespace_packages(...)/find_namespace` or `find_packages(...)/find`,
          you can try to use `exclude_package_data`, or `include-package-data=False` in
          combination with a more fine grained `package-data` configuration.

          You can read more about "package data files" on setuptools documentation page:

          - https://setuptools.pypa.io/en/latest/userguide/datafiles.html


          [^1]: For Python, any directory (with suitable naming) can be imported,
                even if it does not contain any `.py` files.
                On the other hand, currently there is no concept of package data
                directory, all directories are treated like packages.
          ********************************************************************************

  !!
    check.warn(importable)
  /Users/esc/miniconda3-arm64/conda-bld/numba_rvsdg_1691595069250/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_/lib/python3.11/site-packages/setuptools/command/build_py.py:201: _Warning: Package 'numba_rvsdg.core.datastructures' is absent from the `packages` configuration.
  !!

          ********************************************************************************
          ############################
          # Package would be ignored #
          ############################
          Python recognizes 'numba_rvsdg.core.datastructures' as an importable package[^1],
          but it is absent from setuptools' `packages` configuration.

          This leads to an ambiguous overall configuration. If you want to distribute this
          package, please make sure that 'numba_rvsdg.core.datastructures' is explicitly added
          to the `packages` configuration field.

          Alternatively, you can also rely on setuptools' discovery methods
          (for example by using `find_namespace_packages(...)`/`find_namespace:`
          instead of `find_packages(...)`/`find:`).

          You can read more about "package discovery" on setuptools documentation page:

          - https://setuptools.pypa.io/en/latest/userguide/package_discovery.html

          If you don't want 'numba_rvsdg.core.datastructures' to be distributed and are
          already explicitly excluding 'numba_rvsdg.core.datastructures' via
          `find_namespace_packages(...)/find_namespace` or `find_packages(...)/find`,
          you can try to use `exclude_package_data`, or `include-package-data=False` in
          combination with a more fine grained `package-data` configuration.

          You can read more about "package data files" on setuptools documentation page:

          - https://setuptools.pypa.io/en/latest/userguide/datafiles.html


          [^1]: For Python, any directory (with suitable naming) can be imported,
                even if it does not contain any `.py` files.
                On the other hand, currently there is no concept of package data
                directory, all directories are treated like packages.
          ********************************************************************************

  !!
    check.warn(importable)
  /Users/esc/miniconda3-arm64/conda-bld/numba_rvsdg_1691595069250/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_/lib/python3.11/site-packages/setuptools/command/build_py.py:201: _Warning: Package 'numba_rvsdg.networkx_vendored' is absent from the `packages` configuration.
  !!

          ********************************************************************************
          ############################
          # Package would be ignored #
          ############################
          Python recognizes 'numba_rvsdg.networkx_vendored' as an importable package[^1],
          but it is absent from setuptools' `packages` configuration.

          This leads to an ambiguous overall configuration. If you want to distribute this
          package, please make sure that 'numba_rvsdg.networkx_vendored' is explicitly added
          to the `packages` configuration field.

          Alternatively, you can also rely on setuptools' discovery methods
          (for example by using `find_namespace_packages(...)`/`find_namespace:`
          instead of `find_packages(...)`/`find:`).

          You can read more about "package discovery" on setuptools documentation page:

          - https://setuptools.pypa.io/en/latest/userguide/package_discovery.html

          If you don't want 'numba_rvsdg.networkx_vendored' to be distributed and are
          already explicitly excluding 'numba_rvsdg.networkx_vendored' via
          `find_namespace_packages(...)/find_namespace` or `find_packages(...)/find`,
          you can try to use `exclude_package_data`, or `include-package-data=False` in
          combination with a more fine grained `package-data` configuration.

          You can read more about "package data files" on setuptools documentation page:

          - https://setuptools.pypa.io/en/latest/userguide/datafiles.html


          [^1]: For Python, any directory (with suitable naming) can be imported,
                even if it does not contain any `.py` files.
                On the other hand, currently there is no concept of package data
                directory, all directories are treated like packages.
          ********************************************************************************

  !!
    check.warn(importable)
  /Users/esc/miniconda3-arm64/conda-bld/numba_rvsdg_1691595069250/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_/lib/python3.11/site-packages/setuptools/command/build_py.py:201: _Warning: Package 'numba_rvsdg.rendering' is absent from the `packages` configuration.
  !!

          ********************************************************************************
          ############################
          # Package would be ignored #
          ############################
          Python recognizes 'numba_rvsdg.rendering' as an importable package[^1],
          but it is absent from setuptools' `packages` configuration.

          This leads to an ambiguous overall configuration. If you want to distribute this
          package, please make sure that 'numba_rvsdg.rendering' is explicitly added
          to the `packages` configuration field.

          Alternatively, you can also rely on setuptools' discovery methods
          (for example by using `find_namespace_packages(...)`/`find_namespace:`
          instead of `find_packages(...)`/`find:`).

          You can read more about "package discovery" on setuptools documentation page:

          - https://setuptools.pypa.io/en/latest/userguide/package_discovery.html

          If you don't want 'numba_rvsdg.rendering' to be distributed and are
          already explicitly excluding 'numba_rvsdg.rendering' via
          `find_namespace_packages(...)/find_namespace` or `find_packages(...)/find`,
          you can try to use `exclude_package_data`, or `include-package-data=False` in
          combination with a more fine grained `package-data` configuration.

          You can read more about "package data files" on setuptools documentation page:

          - https://setuptools.pypa.io/en/latest/userguide/datafiles.html


          [^1]: For Python, any directory (with suitable naming) can be imported,
                even if it does not contain any `.py` files.
                On the other hand, currently there is no concept of package data
                directory, all directories are treated like packages.
          ********************************************************************************

  !!
    check.warn(importable)
  /Users/esc/miniconda3-arm64/conda-bld/numba_rvsdg_1691595069250/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_/lib/python3.11/site-packages/setuptools/command/build_py.py:201: _Warning: Package 'numba_rvsdg.tests' is absent from the `packages` configuration.
  !!

          ********************************************************************************
          ############################
          # Package would be ignored #
          ############################
          Python recognizes 'numba_rvsdg.tests' as an importable package[^1],
          but it is absent from setuptools' `packages` configuration.

          This leads to an ambiguous overall configuration. If you want to distribute this
          package, please make sure that 'numba_rvsdg.tests' is explicitly added
          to the `packages` configuration field.

          Alternatively, you can also rely on setuptools' discovery methods
          (for example by using `find_namespace_packages(...)`/`find_namespace:`
          instead of `find_packages(...)`/`find:`).

          You can read more about "package discovery" on setuptools documentation page:

          - https://setuptools.pypa.io/en/latest/userguide/package_discovery.html

          If you don't want 'numba_rvsdg.tests' to be distributed and are
          already explicitly excluding 'numba_rvsdg.tests' via
          `find_namespace_packages(...)/find_namespace` or `find_packages(...)/find`,
          you can try to use `exclude_package_data`, or `include-package-data=False` in
          combination with a more fine grained `package-data` configuration.

          You can read more about "package data files" on setuptools documentation page:

          - https://setuptools.pypa.io/en/latest/userguide/datafiles.html


          [^1]: For Python, any directory (with suitable naming) can be imported,
                even if it does not contain any `.py` files.
                On the other hand, currently there is no concept of package data
                directory, all directories are treated like packages.
          ********************************************************************************

  !!
    check.warn(importable)
  creating build/lib/numba_rvsdg/core
  copying numba_rvsdg/core/transformations.py -> build/lib/numba_rvsdg/core
  copying numba_rvsdg/core/utils.py -> build/lib/numba_rvsdg/core
  creating build/lib/numba_rvsdg/core/datastructures
  copying numba_rvsdg/core/datastructures/basic_block.py -> build/lib/numba_rvsdg/core/datastructures
  copying numba_rvsdg/core/datastructures/block_names.py -> build/lib/numba_rvsdg/core/datastructures
  copying numba_rvsdg/core/datastructures/byte_flow.py -> build/lib/numba_rvsdg/core/datastructures
  copying numba_rvsdg/core/datastructures/flow_info.py -> build/lib/numba_rvsdg/core/datastructures
  copying numba_rvsdg/core/datastructures/scfg.py -> build/lib/numba_rvsdg/core/datastructures
  creating build/lib/numba_rvsdg/networkx_vendored
  copying numba_rvsdg/networkx_vendored/scc.py -> build/lib/numba_rvsdg/networkx_vendored
  creating build/lib/numba_rvsdg/rendering
  copying numba_rvsdg/rendering/rendering.py -> build/lib/numba_rvsdg/rendering
  creating build/lib/numba_rvsdg/tests
  copying numba_rvsdg/tests/mock_asm.py -> build/lib/numba_rvsdg/tests
  copying numba_rvsdg/tests/simulator.py -> build/lib/numba_rvsdg/tests
  copying numba_rvsdg/tests/test_byteflow.py -> build/lib/numba_rvsdg/tests
  copying numba_rvsdg/tests/test_mock_asm.py -> build/lib/numba_rvsdg/tests
  copying numba_rvsdg/tests/test_scfg.py -> build/lib/numba_rvsdg/tests
  copying numba_rvsdg/tests/test_simulate.py -> build/lib/numba_rvsdg/tests
  copying numba_rvsdg/tests/test_transforms.py -> build/lib/numba_rvsdg/tests
  copying numba_rvsdg/tests/test_utils.py -> build/lib/numba_rvsdg/tests
  warning: build_py: byte-compiling is disabled, skipping.

  installing to build/bdist.macosx-11.1-arm64/wheel
  running install
  running install_lib
  creating build/bdist.macosx-11.1-arm64
  creating build/bdist.macosx-11.1-arm64/wheel
  creating build/bdist.macosx-11.1-arm64/wheel/numba_rvsdg
  creating build/bdist.macosx-11.1-arm64/wheel/numba_rvsdg/core
  copying build/lib/numba_rvsdg/core/transformations.py -> build/bdist.macosx-11.1-arm64/wheel/numba_rvsdg/core
  creating build/bdist.macosx-11.1-arm64/wheel/numba_rvsdg/core/datastructures
  copying build/lib/numba_rvsdg/core/datastructures/basic_block.py -> build/bdist.macosx-11.1-arm64/wheel/numba_rvsdg/core/datastructures
  copying build/lib/numba_rvsdg/core/datastructures/scfg.py -> build/bdist.macosx-11.1-arm64/wheel/numba_rvsdg/core/datastructures
  copying build/lib/numba_rvsdg/core/datastructures/flow_info.py -> build/bdist.macosx-11.1-arm64/wheel/numba_rvsdg/core/datastructures
  copying build/lib/numba_rvsdg/core/datastructures/byte_flow.py -> build/bdist.macosx-11.1-arm64/wheel/numba_rvsdg/core/datastructures
  copying build/lib/numba_rvsdg/core/datastructures/block_names.py -> build/bdist.macosx-11.1-arm64/wheel/numba_rvsdg/core/datastructures
  copying build/lib/numba_rvsdg/core/utils.py -> build/bdist.macosx-11.1-arm64/wheel/numba_rvsdg/core
  creating build/bdist.macosx-11.1-arm64/wheel/numba_rvsdg/networkx_vendored
  copying build/lib/numba_rvsdg/networkx_vendored/scc.py -> build/bdist.macosx-11.1-arm64/wheel/numba_rvsdg/networkx_vendored
  creating build/bdist.macosx-11.1-arm64/wheel/numba_rvsdg/tests
  copying build/lib/numba_rvsdg/tests/test_scfg.py -> build/bdist.macosx-11.1-arm64/wheel/numba_rvsdg/tests
  copying build/lib/numba_rvsdg/tests/test_simulate.py -> build/bdist.macosx-11.1-arm64/wheel/numba_rvsdg/tests
  copying build/lib/numba_rvsdg/tests/test_utils.py -> build/bdist.macosx-11.1-arm64/wheel/numba_rvsdg/tests
  copying build/lib/numba_rvsdg/tests/test_byteflow.py -> build/bdist.macosx-11.1-arm64/wheel/numba_rvsdg/tests
  copying build/lib/numba_rvsdg/tests/mock_asm.py -> build/bdist.macosx-11.1-arm64/wheel/numba_rvsdg/tests
  copying build/lib/numba_rvsdg/tests/simulator.py -> build/bdist.macosx-11.1-arm64/wheel/numba_rvsdg/tests
  copying build/lib/numba_rvsdg/tests/test_transforms.py -> build/bdist.macosx-11.1-arm64/wheel/numba_rvsdg/tests
  copying build/lib/numba_rvsdg/tests/test_mock_asm.py -> build/bdist.macosx-11.1-arm64/wheel/numba_rvsdg/tests
  copying build/lib/numba_rvsdg/__init__.py -> build/bdist.macosx-11.1-arm64/wheel/numba_rvsdg
  creating build/bdist.macosx-11.1-arm64/wheel/numba_rvsdg/rendering
  copying build/lib/numba_rvsdg/rendering/rendering.py -> build/bdist.macosx-11.1-arm64/wheel/numba_rvsdg/rendering
  warning: install_lib: byte-compiling is disabled, skipping.

  running install_egg_info
  Copying numba_rvsdg.egg-info to build/bdist.macosx-11.1-arm64/wheel/numba_rvsdg-0.0.2-py3.11.egg-info
  running install_scripts
  creating build/bdist.macosx-11.1-arm64/wheel/numba_rvsdg-0.0.2.dist-info/WHEEL
  creating '/private/tmp/pip-wheel-0xd9jcwe/.tmp-p_ivwmdu/numba_rvsdg-0.0.2-py3-none-any.whl' and adding 'build/bdist.macosx-11.1-arm64/wheel' to it
  adding 'numba_rvsdg/__init__.py'
  adding 'numba_rvsdg/core/transformations.py'
  adding 'numba_rvsdg/core/utils.py'
  adding 'numba_rvsdg/core/datastructures/basic_block.py'
  adding 'numba_rvsdg/core/datastructures/block_names.py'
  adding 'numba_rvsdg/core/datastructures/byte_flow.py'
  adding 'numba_rvsdg/core/datastructures/flow_info.py'
  adding 'numba_rvsdg/core/datastructures/scfg.py'
  adding 'numba_rvsdg/networkx_vendored/scc.py'
  adding 'numba_rvsdg/rendering/rendering.py'
  adding 'numba_rvsdg/tests/mock_asm.py'
  adding 'numba_rvsdg/tests/simulator.py'
  adding 'numba_rvsdg/tests/test_byteflow.py'
  adding 'numba_rvsdg/tests/test_mock_asm.py'
  adding 'numba_rvsdg/tests/test_scfg.py'
  adding 'numba_rvsdg/tests/test_simulate.py'
  adding 'numba_rvsdg/tests/test_transforms.py'
  adding 'numba_rvsdg/tests/test_utils.py'
  adding 'numba_rvsdg-0.0.2.dist-info/LICENSE'
  adding 'numba_rvsdg-0.0.2.dist-info/METADATA'
  adding 'numba_rvsdg-0.0.2.dist-info/WHEEL'
  adding 'numba_rvsdg-0.0.2.dist-info/top_level.txt'
  adding 'numba_rvsdg-0.0.2.dist-info/RECORD'
  removing build/bdist.macosx-11.1-arm64/wheel
  Building wheel for numba-rvsdg (pyproject.toml): finished with status 'done'
  Created wheel for numba-rvsdg: filename=numba_rvsdg-0.0.2-py3-none-any.whl size=44949 sha256=8a3e22c7d5405bad56a70e3b7513129e53526b24ca90065e07e712f800b83eb0
  Stored in directory: /private/tmp/pip-ephem-wheel-cache-9l6cz7ti/wheels/f7/33/27/38b024cf2837c071e84fa6acbe603e1010fab1c5a86d08a5a2
Successfully built numba-rvsdg
Installing collected packages: numba-rvsdg

Successfully installed numba-rvsdg-0.0.2
Removed build tracker: '/private/tmp/pip-build-tracker-a_8tii3x'

Resource usage statistics from building numba_rvsdg:
   Process count: 3
   CPU time: Sys=0:00:00.0, User=0:00:00.0
   Memory: 25.5M
   Disk usage: 60.7K
   Time elapsed: 0:00:08.2


Packaging numba_rvsdg
Packaging numba_rvsdg-0.0.2-46_gac7f5dfa83
number of files: 26
Fixing permissions
Packaged license file/s.
INFO :: Time taken to mark (prefix)
        0 replacements in 0 files was 0.11 seconds
WARNING: Importing conda-verify failed.  Please be sure to test your packages.  conda install conda-verify to make this message go away.
DEBUG:conda_index.index:found subdirs {'noarch', 'osx-arm64'}
DEBUG:conda_index.index.sqlitecache:CondaIndexCache channel_root=/Users/esc/miniconda3-arm64/conda-bld, subdir=noarch db_filename=/Users/esc/miniconda3-arm64/conda-bld/noarch/.cache/cache.db cache_is_brand_new=False
DEBUG:conda_index.index.sqlitecache:noarch listdir
DEBUG:conda_index.index.sqlitecache:noarch save fs state
DEBUG:conda_index.index:noarch find packages to extract
DEBUG:conda_index.index:noarch extract 1 packages
DEBUG:conda_index.index.sqlitecache:cache noarch/numba_rvsdg-0.0.2-46_gac7f5dfa83.tar.bz2
INFO:conda_index.index:noarch cached 36 KB from 1 packages at 3.8 MB/second
DEBUG:conda_index.index.sqlitecache:CondaIndexCache channel_root=/Users/esc/miniconda3-arm64/conda-bld, subdir=osx-arm64 db_filename=/Users/esc/miniconda3-arm64/conda-bld/osx-arm64/.cache/cache.db cache_is_brand_new=False
DEBUG:conda_index.index.sqlitecache:osx-arm64 listdir
DEBUG:conda_index.index.sqlitecache:osx-arm64 save fs state
DEBUG:conda_index.index:osx-arm64 find packages to extract
DEBUG:conda_index.index:osx-arm64 extract 0 packages
INFO:conda_index.index:osx-arm64 cached 0 B from 0 packages at 0 B/second
INFO:conda_index.index:Subdir: noarch Gathering repodata
DEBUG:conda_index.index.sqlitecache:CondaIndexCache channel_root=/Users/esc/miniconda3-arm64/conda-bld, subdir=noarch db_filename=/Users/esc/miniconda3-arm64/conda-bld/noarch/.cache/cache.db cache_is_brand_new=False
INFO:conda_index.index:noarch Writing pre-patch repodata
DEBUG:conda_index.index:_maybe_write /Users/esc/miniconda3-arm64/conda-bld/noarch/repodata_from_packages.json to /Users/esc/miniconda3-arm64/conda-bld/noarch/repodata_from_packages.json
DEBUG:conda_index.index:_maybe_write /Users/esc/miniconda3-arm64/conda-bld/noarch/repodata_from_packages.json.bz2 to /Users/esc/miniconda3-arm64/conda-bld/noarch/repodata_from_packages.json.bz2
DEBUG:conda_index.index:_maybe_remove /Users/esc/miniconda3-arm64/conda-bld/noarch/repodata_from_packages.json.zst from /Users/esc/miniconda3-arm64/conda-bld/noarch/repodata_from_packages.json.zst
INFO:conda_index.index:noarch Applying patch instructions
INFO:conda_index.index:noarch Writing patched repodata
DEBUG:conda_index.index:noarch write patched repodata
DEBUG:conda_index.index:_maybe_write /Users/esc/miniconda3-arm64/conda-bld/noarch/repodata.json to /Users/esc/miniconda3-arm64/conda-bld/noarch/repodata.json
DEBUG:conda_index.index:_maybe_write /Users/esc/miniconda3-arm64/conda-bld/noarch/repodata.json.bz2 to /Users/esc/miniconda3-arm64/conda-bld/noarch/repodata.json.bz2
DEBUG:conda_index.index:_maybe_remove /Users/esc/miniconda3-arm64/conda-bld/noarch/repodata.json.zst from /Users/esc/miniconda3-arm64/conda-bld/noarch/repodata.json.zst
INFO:conda_index.index:noarch Building current_repodata subset
DEBUG:conda_index.index:noarch build current_repodata
INFO:conda_index.index:noarch Writing current_repodata subset
DEBUG:conda_index.index:noarch write current_repodata
DEBUG:conda_index.index:_maybe_write /Users/esc/miniconda3-arm64/conda-bld/noarch/current_repodata.json to /Users/esc/miniconda3-arm64/conda-bld/noarch/current_repodata.json
DEBUG:conda_index.index:_maybe_write /Users/esc/miniconda3-arm64/conda-bld/noarch/current_repodata.json.bz2 to /Users/esc/miniconda3-arm64/conda-bld/noarch/current_repodata.json.bz2
DEBUG:conda_index.index:_maybe_remove /Users/esc/miniconda3-arm64/conda-bld/noarch/current_repodata.json.zst from /Users/esc/miniconda3-arm64/conda-bld/noarch/current_repodata.json.zst
INFO:conda_index.index:noarch Writing index HTML
DEBUG:conda_index.index:noarch write index.html
DEBUG:conda_index.index:_maybe_write /Users/esc/miniconda3-arm64/conda-bld/noarch/index.html to /Users/esc/miniconda3-arm64/conda-bld/noarch/index.html
DEBUG:conda_index.index:noarch finish
INFO:conda_index.index:Completed noarch
INFO:conda_index.index:Subdir: osx-arm64 Gathering repodata
DEBUG:conda_index.index.sqlitecache:CondaIndexCache channel_root=/Users/esc/miniconda3-arm64/conda-bld, subdir=osx-arm64 db_filename=/Users/esc/miniconda3-arm64/conda-bld/osx-arm64/.cache/cache.db cache_is_brand_new=False
INFO:conda_index.index:osx-arm64 Writing pre-patch repodata
DEBUG:conda_index.index:_maybe_write /Users/esc/miniconda3-arm64/conda-bld/osx-arm64/repodata_from_packages.json to /Users/esc/miniconda3-arm64/conda-bld/osx-arm64/repodata_from_packages.json
INFO:conda_index.index:osx-arm64 Applying patch instructions
INFO:conda_index.index:osx-arm64 Writing patched repodata
DEBUG:conda_index.index:osx-arm64 write patched repodata
DEBUG:conda_index.index:_maybe_write /Users/esc/miniconda3-arm64/conda-bld/osx-arm64/repodata.json to /Users/esc/miniconda3-arm64/conda-bld/osx-arm64/repodata.json
INFO:conda_index.index:osx-arm64 Building current_repodata subset
DEBUG:conda_index.index:osx-arm64 build current_repodata
INFO:conda_index.index:osx-arm64 Writing current_repodata subset
DEBUG:conda_index.index:osx-arm64 write current_repodata
DEBUG:conda_index.index:_maybe_write /Users/esc/miniconda3-arm64/conda-bld/osx-arm64/current_repodata.json to /Users/esc/miniconda3-arm64/conda-bld/osx-arm64/current_repodata.json
INFO:conda_index.index:osx-arm64 Writing index HTML
DEBUG:conda_index.index:osx-arm64 write index.html
DEBUG:conda_index.index:_maybe_write /Users/esc/miniconda3-arm64/conda-bld/osx-arm64/index.html to /Users/esc/miniconda3-arm64/conda-bld/osx-arm64/index.html
DEBUG:conda_index.index:osx-arm64 finish
INFO:conda_index.index:Completed osx-arm64
DEBUG:conda_index.index:found subdirs {'noarch', 'osx-arm64'}
INFO:conda_index.index:Channeldata subdir: noarch
DEBUG:conda_index.index:noarch read repodata
DEBUG:conda_index.index.sqlitecache:CondaIndexCache channel_root=/Users/esc/miniconda3-arm64/conda-bld, subdir=noarch db_filename=/Users/esc/miniconda3-arm64/conda-bld/noarch/.cache/cache.db cache_is_brand_new=False
DEBUG:conda_index.index:noarch channeldata finished
INFO:conda_index.index:Channeldata subdir: osx-arm64
DEBUG:conda_index.index:osx-arm64 read repodata
DEBUG:conda_index.index.sqlitecache:CondaIndexCache channel_root=/Users/esc/miniconda3-arm64/conda-bld, subdir=osx-arm64 db_filename=/Users/esc/miniconda3-arm64/conda-bld/osx-arm64/.cache/cache.db cache_is_brand_new=False
DEBUG:conda_index.index:osx-arm64 channeldata finished
DEBUG:conda_index.index:_maybe_write /Users/esc/miniconda3-arm64/conda-bld/index.html to /Users/esc/miniconda3-arm64/conda-bld/index.html
DEBUG:conda_index.index:write channeldata
DEBUG:conda_index.index:_maybe_write /Users/esc/miniconda3-arm64/conda-bld/channeldata.json to /Users/esc/miniconda3-arm64/conda-bld/channeldata.json
TEST START: /Users/esc/miniconda3-arm64/conda-bld/noarch/numba_rvsdg-0.0.2-46_gac7f5dfa83.tar.bz2
DEBUG:conda_index.index:found subdirs {'noarch', 'osx-arm64'}
DEBUG:conda_index.index.sqlitecache:CondaIndexCache channel_root=/Users/esc/miniconda3-arm64/conda-bld, subdir=noarch db_filename=/Users/esc/miniconda3-arm64/conda-bld/noarch/.cache/cache.db cache_is_brand_new=False
DEBUG:conda_index.index.sqlitecache:noarch listdir
DEBUG:conda_index.index.sqlitecache:noarch save fs state
DEBUG:conda_index.index:noarch find packages to extract
DEBUG:conda_index.index:noarch extract 0 packages
INFO:conda_index.index:noarch cached 0 B from 0 packages at 0 B/second
DEBUG:conda_index.index.sqlitecache:CondaIndexCache channel_root=/Users/esc/miniconda3-arm64/conda-bld, subdir=osx-arm64 db_filename=/Users/esc/miniconda3-arm64/conda-bld/osx-arm64/.cache/cache.db cache_is_brand_new=False
DEBUG:conda_index.index.sqlitecache:osx-arm64 listdir
DEBUG:conda_index.index.sqlitecache:osx-arm64 save fs state
DEBUG:conda_index.index:osx-arm64 find packages to extract
DEBUG:conda_index.index:osx-arm64 extract 0 packages
INFO:conda_index.index:osx-arm64 cached 0 B from 0 packages at 0 B/second
INFO:conda_index.index:Subdir: noarch Gathering repodata
DEBUG:conda_index.index.sqlitecache:CondaIndexCache channel_root=/Users/esc/miniconda3-arm64/conda-bld, subdir=noarch db_filename=/Users/esc/miniconda3-arm64/conda-bld/noarch/.cache/cache.db cache_is_brand_new=False
INFO:conda_index.index:noarch Writing pre-patch repodata
DEBUG:conda_index.index:_maybe_write /Users/esc/miniconda3-arm64/conda-bld/noarch/repodata_from_packages.json to /Users/esc/miniconda3-arm64/conda-bld/noarch/repodata_from_packages.json
INFO:conda_index.index:noarch Applying patch instructions
INFO:conda_index.index:noarch Writing patched repodata
DEBUG:conda_index.index:noarch write patched repodata
DEBUG:conda_index.index:_maybe_write /Users/esc/miniconda3-arm64/conda-bld/noarch/repodata.json to /Users/esc/miniconda3-arm64/conda-bld/noarch/repodata.json
INFO:conda_index.index:noarch Building current_repodata subset
DEBUG:conda_index.index:noarch build current_repodata
INFO:conda_index.index:noarch Writing current_repodata subset
DEBUG:conda_index.index:noarch write current_repodata
DEBUG:conda_index.index:_maybe_write /Users/esc/miniconda3-arm64/conda-bld/noarch/current_repodata.json to /Users/esc/miniconda3-arm64/conda-bld/noarch/current_repodata.json
INFO:conda_index.index:noarch Writing index HTML
DEBUG:conda_index.index:noarch write index.html
DEBUG:conda_index.index:_maybe_write /Users/esc/miniconda3-arm64/conda-bld/noarch/index.html to /Users/esc/miniconda3-arm64/conda-bld/noarch/index.html
DEBUG:conda_index.index:noarch finish
INFO:conda_index.index:Completed noarch
INFO:conda_index.index:Subdir: osx-arm64 Gathering repodata
DEBUG:conda_index.index.sqlitecache:CondaIndexCache channel_root=/Users/esc/miniconda3-arm64/conda-bld, subdir=osx-arm64 db_filename=/Users/esc/miniconda3-arm64/conda-bld/osx-arm64/.cache/cache.db cache_is_brand_new=False
INFO:conda_index.index:osx-arm64 Writing pre-patch repodata
DEBUG:conda_index.index:_maybe_write /Users/esc/miniconda3-arm64/conda-bld/osx-arm64/repodata_from_packages.json to /Users/esc/miniconda3-arm64/conda-bld/osx-arm64/repodata_from_packages.json
INFO:conda_index.index:osx-arm64 Applying patch instructions
INFO:conda_index.index:osx-arm64 Writing patched repodata
DEBUG:conda_index.index:osx-arm64 write patched repodata
DEBUG:conda_index.index:_maybe_write /Users/esc/miniconda3-arm64/conda-bld/osx-arm64/repodata.json to /Users/esc/miniconda3-arm64/conda-bld/osx-arm64/repodata.json
INFO:conda_index.index:osx-arm64 Building current_repodata subset
DEBUG:conda_index.index:osx-arm64 build current_repodata
INFO:conda_index.index:osx-arm64 Writing current_repodata subset
DEBUG:conda_index.index:osx-arm64 write current_repodata
DEBUG:conda_index.index:_maybe_write /Users/esc/miniconda3-arm64/conda-bld/osx-arm64/current_repodata.json to /Users/esc/miniconda3-arm64/conda-bld/osx-arm64/current_repodata.json
INFO:conda_index.index:osx-arm64 Writing index HTML
DEBUG:conda_index.index:osx-arm64 write index.html
DEBUG:conda_index.index:_maybe_write /Users/esc/miniconda3-arm64/conda-bld/osx-arm64/index.html to /Users/esc/miniconda3-arm64/conda-bld/osx-arm64/index.html
DEBUG:conda_index.index:osx-arm64 finish
INFO:conda_index.index:Completed osx-arm64
DEBUG:conda_index.index:found subdirs {'noarch', 'osx-arm64'}
INFO:conda_index.index:Channeldata subdir: noarch
DEBUG:conda_index.index:noarch read repodata
DEBUG:conda_index.index.sqlitecache:CondaIndexCache channel_root=/Users/esc/miniconda3-arm64/conda-bld, subdir=noarch db_filename=/Users/esc/miniconda3-arm64/conda-bld/noarch/.cache/cache.db cache_is_brand_new=False
DEBUG:conda_index.index:noarch channeldata finished
INFO:conda_index.index:Channeldata subdir: osx-arm64
DEBUG:conda_index.index:osx-arm64 read repodata
DEBUG:conda_index.index.sqlitecache:CondaIndexCache channel_root=/Users/esc/miniconda3-arm64/conda-bld, subdir=osx-arm64 db_filename=/Users/esc/miniconda3-arm64/conda-bld/osx-arm64/.cache/cache.db cache_is_brand_new=False
DEBUG:conda_index.index:osx-arm64 channeldata finished
DEBUG:conda_index.index:_maybe_write /Users/esc/miniconda3-arm64/conda-bld/index.html to /Users/esc/miniconda3-arm64/conda-bld/index.html
DEBUG:conda_index.index:write channeldata
DEBUG:conda_index.index:_maybe_write /Users/esc/miniconda3-arm64/conda-bld/channeldata.json to /Users/esc/miniconda3-arm64/conda-bld/channeldata.json
Adding in variants from /var/folders/jk/s59wn3zx5g92kvk6t9k74fzr0000gq/T/tmpp_6e85lo/info/recipe/conda_build_config.yaml
Renaming /Users/esc/miniconda3-arm64/conda-bld/numba_rvsdg_1691595069250/_build_env prefix directory '/Users/esc/miniconda3-arm64/conda-bld/numba_rvsdg_1691595069250/_build_env' to '/Users/esc/miniconda3-arm64/conda-bld/numba_rvsdg_1691595069250/build_prefix_moved_numba_rvsdg-0.0.2-46_gac7f5dfa83_osx-arm64'
shutil.move(/Users/esc/miniconda3-arm64/conda-bld/numba_rvsdg_1691595069250/_build_env prefix)=/Users/esc/miniconda3-arm64/conda-bld/numba_rvsdg_1691595069250/_build_env, dest=/Users/esc/miniconda3-arm64/conda-bld/numba_rvsdg_1691595069250/build_prefix_moved_numba_rvsdg-0.0.2-46_gac7f5dfa83_osx-arm64)
Renaming work directory '/Users/esc/miniconda3-arm64/conda-bld/numba_rvsdg_1691595069250/work' to '/Users/esc/miniconda3-arm64/conda-bld/numba_rvsdg_1691595069250/work_moved_numba_rvsdg-0.0.2-46_gac7f5dfa83_noarch'
shutil.move(work)=/Users/esc/miniconda3-arm64/conda-bld/numba_rvsdg_1691595069250/work, dest=/Users/esc/miniconda3-arm64/conda-bld/numba_rvsdg_1691595069250/work_moved_numba_rvsdg-0.0.2-46_gac7f5dfa83_noarch)
Collecting package metadata (repodata.json): ...working... done
Solving environment: ...working... done

## Package Plan ##

  environment location: /Users/esc/miniconda3-arm64/conda-bld/numba_rvsdg_1691595069250/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_place


The following NEW packages will be INSTALLED:

    boost-cpp:                 1.73.0-h1a28f6b_12      defaults
    bzip2:                     1.0.8-h620ffc9_4        defaults
    c-ares:                    1.19.0-h80987f9_0       defaults
    ca-certificates:           2023.05.30-hca03da5_0   defaults
    cairo:                     1.16.0-h302bd0f_5       defaults
    expat:                     2.4.9-hc377ac9_0        defaults
    font-ttf-dejavu-sans-mono: 2.37-hd3eb1b0_0         defaults
    font-ttf-inconsolata:      2.001-hcb22688_0        defaults
    font-ttf-source-code-pro:  2.030-hd3eb1b0_0        defaults
    font-ttf-ubuntu:           0.83-h8b1ccd4_0         defaults
    fontconfig:                2.14.1-hee714a5_2       defaults
    fonts-anaconda:            1-h8fa9717_0            defaults
    fonts-conda-ecosystem:     1-hd3eb1b0_0            defaults
    freetype:                  2.12.1-h1192e45_0       defaults
    fribidi:                   1.0.10-h1a28f6b_0       defaults
    gdk-pixbuf:                2.42.10-h80987f9_0      defaults
    gettext:                   0.21.0-h13f89a0_1       defaults
    giflib:                    5.2.1-h80987f9_3        defaults
    glib:                      2.69.1-h514c7bf_2       defaults
    graphite2:                 1.3.14-hc377ac9_1       defaults
    graphviz:                  2.50.0-hf331ead_1       defaults
    gts:                       0.7.6-hde733a8_3        defaults
    harfbuzz:                  4.3.0-he9eebac_1        defaults
    icu:                       68.1-hc377ac9_0         defaults
    iniconfig:                 1.1.1-pyhd3eb1b0_0      defaults
    jpeg:                      9e-h80987f9_1           defaults
    krb5:                      1.20.1-hf3e1bf2_1       defaults
    lcms2:                     2.12-hba8e193_0         defaults
    lerc:                      3.0-hc377ac9_0          defaults
    libboost:                  1.73.0-h49e8a49_12      defaults
    libcurl:                   8.1.1-h3e2b118_2        defaults
    libcxx:                    14.0.6-h848a8c0_0       defaults
    libdeflate:                1.17-h80987f9_0         defaults
    libedit:                   3.1.20221030-h80987f9_0 defaults
    libev:                     4.33-h1a28f6b_1         defaults
    libffi:                    3.4.4-hca03da5_0        defaults
    libgd:                     2.3.3-h313beb8_2        defaults
    libiconv:                  1.16-h1a28f6b_2         defaults
    libnghttp2:                1.52.0-h62f6fdd_1       defaults
    libpng:                    1.6.39-h80987f9_0       defaults
    librsvg:                   2.54.4-hb3bd4c3_3       defaults
    libssh2:                   1.10.0-h02f6b3c_2       defaults
    libtiff:                   4.5.0-h313beb8_2        defaults
    libtool:                   2.4.6-h313beb8_1009     defaults
    libwebp:                   1.2.4-ha3663a8_1        defaults
    libwebp-base:              1.2.4-h80987f9_1        defaults
    libxml2:                   2.10.3-h372ba2a_0       defaults
    llvm-openmp:               14.0.6-hc6e5704_0       defaults
    lz4-c:                     1.9.4-h313beb8_0        defaults
    ncurses:                   6.4-h313beb8_0          defaults
    nspr:                      4.35-h313beb8_0         defaults
    nss:                       3.89.1-h313beb8_0       defaults
    numba_rvsdg:               0.0.2-46_gac7f5dfa83    local
    openjpeg:                  2.3.0-h7a6adac_2        defaults
    openssl:                   3.0.10-h1a28f6b_0       defaults
    packaging:                 23.0-py311hca03da5_0    defaults
    pango:                     1.50.7-h7271ec9_0       defaults
    pcre:                      8.45-hc377ac9_0         defaults
    pip:                       23.2.1-py311hca03da5_0  defaults
    pixman:                    0.40.0-h1a28f6b_0       defaults
    pluggy:                    1.0.0-py311hca03da5_1   defaults
    poppler:                   22.12.0-h497017c_0      defaults
    poppler-data:              0.4.11-hca03da5_1       defaults
    pytest:                    7.4.0-py311hca03da5_0   defaults
    python:                    3.11.4-hb885b13_0       defaults
    python-graphviz:           0.20.1-py311hca03da5_0  defaults
    pyyaml:                    6.0-py311h80987f9_1     defaults
    readline:                  8.2-h1a28f6b_0          defaults
    setuptools:                68.0.0-py311hca03da5_0  defaults
    sqlite:                    3.41.2-h80987f9_0       defaults
    tk:                        8.6.12-hb8d0fd4_0       defaults
    tzdata:                    2023c-h04d1e81_0        defaults
    wheel:                     0.38.4-py311hca03da5_0  defaults
    xz:                        5.4.2-h80987f9_0        defaults
    yaml:                      0.2.5-h1a28f6b_0        defaults
    zlib:                      1.2.13-h5a0b063_0       defaults
    zstd:                      1.5.5-hd90d995_0        defaults

Preparing transaction: ...working... done
Verifying transaction: ...working... done
Executing transaction: ...working... done
export PREFIX=/Users/esc/miniconda3-arm64/conda-bld/numba_rvsdg_1691595069250/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_place
export SRC_DIR=/Users/esc/miniconda3-arm64/conda-bld/numba_rvsdg_1691595069250/test_tmp
+ pytest --pyargs numba_rvsdg
============================= test session starts ==============================
platform darwin -- Python 3.11.4, pytest-7.4.0, pluggy-1.0.0
rootdir: $SRC_DIR
collected 43 items

tests/test_byteflow.py .........                                         [ 20%]
tests/test_mock_asm.py ...                                               [ 27%]
tests/test_scfg.py ....                                                  [ 37%]
tests/test_simulate.py ........                                          [ 55%]
tests/test_transforms.py ...................                             [100%]

============================== 43 passed in 2.79s ==============================
+ exit 0

Resource usage statistics from testing numba_rvsdg:
   Process count: 4
   CPU time: Sys=0:00:00.2, User=0:00:02.6
   Memory: 55.7M
   Disk usage: 80B
   Time elapsed: 0:00:06.1


TEST END: /Users/esc/miniconda3-arm64/conda-bld/noarch/numba_rvsdg-0.0.2-46_gac7f5dfa83.tar.bz2
Renaming work directory '/Users/esc/miniconda3-arm64/conda-bld/numba_rvsdg_1691595069250/work' to '/Users/esc/miniconda3-arm64/conda-bld/numba_rvsdg_1691595069250/work_moved_numba_rvsdg-0.0.2-46_gac7f5dfa83_osx-arm64_main_build_loop'
shutil.move(work)=/Users/esc/miniconda3-arm64/conda-bld/numba_rvsdg_1691595069250/work, dest=/Users/esc/miniconda3-arm64/conda-bld/numba_rvsdg_1691595069250/work_moved_numba_rvsdg-0.0.2-46_gac7f5dfa83_osx-arm64_main_build_loop)
# Automatic uploading is disabled
# If you want to upload package(s) to anaconda.org later, type:


# To have conda build upload to anaconda.org automatically, use
# conda config --set anaconda_upload yes
anaconda upload \
    /Users/esc/miniconda3-arm64/conda-bld/noarch/numba_rvsdg-0.0.2-46_gac7f5dfa83.tar.bz2
anaconda_upload is not set.  Not uploading wheels: []

INFO :: The inputs making up the hashes for the built packages are as follows:
{
  "numba_rvsdg-0.0.2-46_gac7f5dfa83": {
    "recipe": {}
  }
}


####################################################################################
Resource usage summary:

Total time: 0:01:00.6
CPU usage: sys=0:00:00.2, user=0:00:02.7
Maximum memory usage observed: 55.7M
Total disk usage observed (not including envs): 60.8K


####################################################################################
Source and build intermediates have been left in /Users/esc/miniconda3-arm64/conda-bld.
There are currently 1 accumulated.
To remove them, you can run the ```conda build purge``` command
  15.02s user 17.24s system 52% cpu 1:01.51 total
```

As you can see, the resulting package is both `noarch` and includes the current git info in it's build-string (and not the version number):

