### PR TITLE
Fixups 0.0.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ permissions:
 on:
   push:
     tags:
-      - v[0-9]+.[0-9]+.[0-9]+
+      - [0-9]+.[0-9]+.[0-9]+
 
 jobs:
   # First we are going to create a task that generates a new release in GitHub

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,7 +2,7 @@
 Release Notes
 =============
 
-Version 0.0.3 - 2023-08-11
+Version 0.0.4 - 2023-08-11
 ==========================
 
 This is a minimal maintenance update to support inclusion of ``numba-rvsdg`` as
@@ -21,6 +21,11 @@ Authors:
 * `kc611 <https://github.com/kc611>`_
 * `sklam <https://github.com/sklam>`_
 * `esc <https://github.com/esc>`_
+
+Version 0.0.3 - 2023-08-11
+==========================
+
+* RELEASE FAILED
 
 Version 0.0.2 - 2023-06-22
 ==========================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "numba_rvsdg"
-version = "0.0.2"
+version = "0.0.4"
 authors = [
     {name = "Numba Developers", email="none@none.none"},
 ]


### PR DESCRIPTION
The 0.0.3 release failed because of multiple human errors, so these are the fixups that resulted from the learnings.

a) The version number must be set in the `pyproject.toml`
b) The `release.yml` workflow was detecting tags with `v` prefix
c) The release notes were updated to indicate the 0.0.3 failure and now releasing as 0.0.4 instead.