### PR TITLE
fix regex when detecting tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ permissions:
 on:
   push:
     tags:
-      - v[0-9]+.[0-9]+.[0-9]+
+      - "[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
   # First we are going to create a task that generates a new release in GitHub


### PR DESCRIPTION
The tags for the numba-rvsdg project don't use a "v" as prefix. We remove this and encase the regex in quotes to ensure it is valid YAML.