### PR TITLE
update release_notes for 0.0.4 and 0.0.5

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,6 +2,46 @@
 Release Notes
 =============
 
+Version 0.0.5 - 2023-08-11
+==========================
+
+This is a maintenance release to fix the name of the conda package such that it
+matches the name of the PyPi project: `numba-rvsdg`.
+
+Pull-Requests:
+
+* PR `#103 <https://github.com/numba/numba-rvsdg/pull/103>`_: numba_rvsdg -> numba-rvsdg (`esc <https://github.com/esc>`_)
+* PR `#104 <https://github.com/numba/numba-rvsdg/pull/104>`_: fix regex when detecting tags (`esc <https://github.com/esc>`_)
+
+Authors:
+
+* `esc <https://github.com/esc>`_
+
+Version 0.0.4 - 2023-08-11
+==========================
+
+This is a minimal maintenance update to support inclusion of ``numba-rvsdg`` as
+an optional dependency in Numba 0.58.
+
+Pull-Requests:
+
+* PR `#89 <https://github.com/numba/numba-rvsdg/pull/89>`_: Create a GitHub Action to build wheels (`esc <https://github.com/esc>`_ `apmasell <https://github.com/apmasell>`_)
+* PR `#91 <https://github.com/numba/numba-rvsdg/pull/91>`_: Add conda-recipe (`sklam <https://github.com/sklam>`_)
+* PR `#92 <https://github.com/numba/numba-rvsdg/pull/92>`_: Patching debug logging calls and debug print statements (`kc611 <https://github.com/kc611>`_)
+* PR `#97 <https://github.com/numba/numba-rvsdg/pull/97>`_: updates to the conda-recipe using grayskull (`esc <https://github.com/esc>`_)
+
+Authors:
+
+* `apmasell <https://github.com/apmasell>`_
+* `kc611 <https://github.com/kc611>`_
+* `sklam <https://github.com/sklam>`_
+* `esc <https://github.com/esc>`_
+
+Version 0.0.3 - 2023-08-11
+==========================
+
+* RELEASE FAILED
+
 Version 0.0.2 - 2023-06-22
 ==========================
 


### PR DESCRIPTION
Updates via the `release_0.0.5` branch.