### PR TITLE
Simulator test fixes for Python 3.12 version upgrade

### DIFF
--- a/numba_rvsdg/core/utils.py
+++ b/numba_rvsdg/core/utils.py
@@ -5,6 +5,7 @@ _logger = logging.getLogger(__name__)
 
 PYVERSION = sys.version_info[:2]
 
+
 class _LogWrap:
     def __init__(self, fn):  # type: ignore
         self._fn = fn

--- a/numba_rvsdg/core/utils.py
+++ b/numba_rvsdg/core/utils.py
@@ -1,7 +1,9 @@
 import logging
+import sys
 
 _logger = logging.getLogger(__name__)
 
+PYVERSION = sys.version_info[:2]
 
 class _LogWrap:
     def __init__(self, fn):  # type: ignore

--- a/numba_rvsdg/tests/simulator.py
+++ b/numba_rvsdg/tests/simulator.py
@@ -331,10 +331,12 @@ class Simulator:
             ind = next(tos)
         except StopIteration:
             self.branch = True
-            if PYVERSION <= (3, 11):
+            if PYVERSION in ((3, 11),):
                 self.stack.pop()
-            else:
+            elif PYVERSION in ((3, 12),):
                 self.stack.append(None)
+            else:
+                raise NotImplementedError(PYVERSION)
         else:
             self.branch = False
             self.stack.append(ind)

--- a/numba_rvsdg/tests/simulator.py
+++ b/numba_rvsdg/tests/simulator.py
@@ -12,6 +12,7 @@ from numba_rvsdg.core.utils import PYVERSION
 
 import builtins
 
+
 class Simulator:
     """SCFG simulator.
 
@@ -434,6 +435,7 @@ class Simulator:
         self.stack.pop()
 
     if PYVERSION in ((3, 12),):
+
         def op_END_FOR(self, inst):
             self.stack.pop()
             self.stack.pop()

--- a/numba_rvsdg/tests/simulator.py
+++ b/numba_rvsdg/tests/simulator.py
@@ -440,6 +440,11 @@ class Simulator:
             self.stack.pop()
             self.stack.pop()
 
+    else:
+
+        def op_END_FOR(self, inst):
+            raise NotImplementedError(PYVERSION)
+
     def op_COPY(self, inst):
         assert inst.argval > 0
         self.stack.append(self.stack[-inst.argval])

--- a/numba_rvsdg/tests/simulator.py
+++ b/numba_rvsdg/tests/simulator.py
@@ -8,12 +8,9 @@ from numba_rvsdg.core.datastructures.basic_block import (
     RegionBlock,
     SyntheticBlock,
 )
+from numba_rvsdg.core.utils import PYVERSION
 
 import builtins
-import sys
-
-PYVERSION = sys.version_info[:2]
-
 
 class Simulator:
     """SCFG simulator.

--- a/numba_rvsdg/tests/simulator.py
+++ b/numba_rvsdg/tests/simulator.py
@@ -436,9 +436,10 @@ class Simulator:
         self.branch = self.stack[-1] is None
         self.stack.pop()
 
-    def op_END_FOR(self, inst):
-        self.stack.pop()
-        self.stack.pop()
+    if PYVERSION in ((3, 12),):
+        def op_END_FOR(self, inst):
+            self.stack.pop()
+            self.stack.pop()
 
     def op_COPY(self, inst):
         assert inst.argval > 0

--- a/numba_rvsdg/tests/simulator.py
+++ b/numba_rvsdg/tests/simulator.py
@@ -10,6 +10,9 @@ from numba_rvsdg.core.datastructures.basic_block import (
 )
 
 import builtins
+import sys
+
+PYVERSION = sys.version_info[:2]
 
 
 class Simulator:
@@ -327,8 +330,11 @@ class Simulator:
         try:
             ind = next(tos)
         except StopIteration:
-            self.stack.pop()
             self.branch = True
+            if PYVERSION <= (3, 11):
+                self.stack.pop()
+            else:
+                self.stack.append(None)
         else:
             self.branch = False
             self.stack.append(ind)
@@ -427,3 +433,11 @@ class Simulator:
     def op_POP_JUMP_BACKWARD_IF_NONE(self, inst):
         self.branch = self.stack[-1] is None
         self.stack.pop()
+
+    def op_END_FOR(self, inst):
+        self.stack.pop()
+        self.stack.pop()
+
+    def op_COPY(self, inst):
+        assert inst.argval > 0
+        self.stack.append(self.stack[-inst.argval])


### PR DESCRIPTION
As titled,

This PR adds a fixes for the simulator tests that fail during shift to Python 3.12.