### PR TITLE
update REAMDE and add makefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,20 +17,34 @@ bytecode.
 
 ## dependencies
 
-* Python 3.11
+* Python 3.11 or 3.12
+* make (optional, build tool)
 * graphviz
 * pyyaml
+* pytest (for testing)
+* sphinx (for docs)
+* sphinx_rt_theme (for docs)
 
 You can create a conda env using the following:
 
 ```
-conda env create -n numba-rvsdg python=3.11 python-graphviz
-conda activate numba-rvsdg
-pip install pyyaml
+$ conda env create -n numba-rvsdg python=3.12 python-graphviz pyyaml pytest sphinx sphinx_rtd_theme
+$ conda activate numba-rvsdg
 ```
 
-At the time of writing `pyyaml` was not available for Python 3.11 via
-`defaults` so it had to be installed with `pip`.
+If you have `make` and `conda` available, a common workflow could be:
+
+```
+$ make conda-env                        # setup conda environment
+$ conda activate numba-rvsdg            # activate it
+$ make                                  # "build" the project
+$ make test                             # run all tests
+$ make docs                             # build the docs
+$ open docs/build/html/index.html       # view the docs (OSX)
+```
+
+Feel free to look at the `makefile` for low-level commands.
+
 
 ## overview
 

--- a/makefile
+++ b/makefile
@@ -1,0 +1,9 @@
+.PHONY: build test docs env
+build:
+	python -m pip install -vv -e .
+test:
+	pytest --pyargs numba_rvsdg
+docs:
+	cd docs && make html
+conda-env:
+	conda create -n numba-rvsdg python=3.12 python-graphviz pyyaml pytest sphinx sphinx_rtd_theme


### PR DESCRIPTION
The README now contains instructions based on the current state of the available dependencies for Python 3.12. All of these are now available from conda and no additional packages need to be installed via pip.

The makefiles is largely self-explanatory and contains all the low level commands to build the project, run all the tests and to render the documentation. It serves as a common entry-point for developers and services alike.