### PR TITLE
Enhance rendering SCFGs

### DIFF
--- a/numba_rvsdg/tests/test_rendering.py
+++ b/numba_rvsdg/tests/test_rendering.py
@@ -8,24 +8,17 @@ from numba_rvsdg.core.datastructures.scfg import SCFG
 from numba_rvsdg.rendering.rendering import SCFGRenderer
 
 expected_original = r"""digraph {
-	0 [label="0\l
-jump targets: ('1', '2')
-back edges: ()" shape=rect]
-	1 [label="1\l
-jump targets: ('3',)
-back edges: ()" shape=rect]
-	2 [label="2\l
-jump targets: ('4',)
-back edges: ()" shape=rect]
-	3 [label="3\l
-jump targets: ('2', '5')
-back edges: ()" shape=rect]
-	4 [label="4\l
-jump targets: ('1',)
-back edges: ()" shape=rect]
-	5 [label="5\l
-jump targets: ()
-back edges: ()" shape=rect]
+	0 [label="0\n
+jump targets: ('1', '2')" shape=rect style=rounded]
+	1 [label="1\n
+jump targets: ('3',)" shape=rect style=rounded]
+	2 [label="2\n
+jump targets: ('4',)" shape=rect style=rounded]
+	3 [label="3\n
+jump targets: ('2', '5')" shape=rect style=rounded]
+	4 [label="4\n
+jump targets: ('1',)" shape=rect style=rounded]
+	5 [label="5\n" shape=rect style=rounded]
 	0 -> 1
 	0 -> 2
 	1 -> 3
@@ -37,109 +30,81 @@ back edges: ()" shape=rect]
 
 expected_restructured = r"""digraph {
 	subgraph cluster_head_region_0 {
-		color=red label="head_region_0
-jump targets: ('branch_region_0', 'branch_region_1')
-back edges: ()"
-		0 [label="0\l
-jump targets: ('branch_region_0', 'branch_region_1')
-back edges: ()" shape=rect]
+		color=red label="head_region_0\n
+jump targets: ('branch_region_0', 'branch_region_1')" shape=rect style=rounded
+		0 [label="0\n
+jump targets: ('branch_region_0', 'branch_region_1')" shape=rect style=rounded]
 	}
 	subgraph cluster_branch_region_0 {
-		color=green label="branch_region_0
-jump targets: ('tail_region_0',)
-back edges: ()"
-		synth_asign_block_0 [label="synth_asign_block_0\l__scfg_control_var_0__ = 0
-jump targets: ('tail_region_0',)
-back edges: ()" shape=rect]
+		color=green label="branch_region_0\n
+jump targets: ('tail_region_0',)" shape=rect style=rounded
+		synth_asign_block_0 [label="synth_asign_block_0\n\l__scfg_control_var_0__ = 0\l
+jump targets: ('tail_region_0',)" shape=rect style=rounded]
 	}
 	subgraph cluster_branch_region_1 {
-		color=green label="branch_region_1
-jump targets: ('tail_region_0',)
-back edges: ()"
-		synth_asign_block_1 [label="synth_asign_block_1\l__scfg_control_var_0__ = 1
-jump targets: ('tail_region_0',)
-back edges: ()" shape=rect]
+		color=green label="branch_region_1\n
+jump targets: ('tail_region_0',)" shape=rect style=rounded
+		synth_asign_block_1 [label="synth_asign_block_1\n\l__scfg_control_var_0__ = 1\l
+jump targets: ('tail_region_0',)" shape=rect style=rounded]
 	}
 	subgraph cluster_tail_region_0 {
-		color=purple label="tail_region_0
-jump targets: ()
-back edges: ()"
-		5 [label="5\l
-jump targets: ()
-back edges: ()" shape=rect]
+		color=purple label="tail_region_0\n" shape=rect style=rounded
+		5 [label="5\n" shape=rect style=rounded]
 		subgraph cluster_loop_region_0 {
-			color=blue label="loop_region_0
-jump targets: ('5',)
-back edges: ()"
+			color=blue label="loop_region_0\n
+jump targets: ('5',)" shape=rect style=rounded
 			subgraph cluster_head_region_1 {
-				color=red label="head_region_1
-jump targets: ('branch_region_2', 'branch_region_3')
-back edges: ()"
-				synth_head_block_0 [label="synth_head_block_0\lvariable: __scfg_control_var_0__\l0=>branch_region_2\l1=>branch_region_3
-jump targets: ('branch_region_2', 'branch_region_3')
-back edges: ()" shape=rect]
+				color=red label="head_region_1\n
+jump targets: ('branch_region_2', 'branch_region_3')" shape=rect style=rounded
+				synth_head_block_0 [label="synth_head_block_0\n\lvariable: __scfg_control_var_0__\l0 → branch_region_2\l1 → branch_region_3\l
+jump targets: ('branch_region_2', 'branch_region_3')" shape=rect style=rounded]
 			}
 			subgraph cluster_branch_region_2 {
-				color=green label="branch_region_2
-jump targets: ('tail_region_1',)
-back edges: ()"
+				color=green label="branch_region_2\n
+jump targets: ('tail_region_1',)" shape=rect style=rounded
 				subgraph cluster_head_region_2 {
-					color=red label="head_region_2
-jump targets: ('branch_region_4', 'branch_region_5')
-back edges: ()"
-					1 [label="1\l
-jump targets: ('3',)
-back edges: ()" shape=rect]
-					3 [label="3\l
-jump targets: ('branch_region_4', 'branch_region_5')
-back edges: ()" shape=rect]
+					color=red label="head_region_2\n
+jump targets: ('branch_region_4', 'branch_region_5')" shape=rect style=rounded
+					1 [label="1\n
+jump targets: ('3',)" shape=rect style=rounded]
+					3 [label="3\n
+jump targets: ('branch_region_4', 'branch_region_5')" shape=rect style=rounded]
 				}
 				subgraph cluster_branch_region_4 {
-					color=green label="branch_region_4
-jump targets: ('tail_region_2',)
-back edges: ()"
-					synth_asign_block_2 [label="synth_asign_block_2\l__scfg_backedge_var_0__ = 0\l__scfg_control_var_0__ = 1
-jump targets: ('tail_region_2',)
-back edges: ()" shape=rect]
+					color=green label="branch_region_4\n
+jump targets: ('tail_region_2',)" shape=rect style=rounded
+					synth_asign_block_2 [label="synth_asign_block_2\n\l__scfg_backedge_var_0__ = 0\l__scfg_control_var_0__ = 1\l
+jump targets: ('tail_region_2',)" shape=rect style=rounded]
 				}
 				subgraph cluster_branch_region_5 {
-					color=green label="branch_region_5
-jump targets: ('tail_region_2',)
-back edges: ()"
-					synth_asign_block_3 [label="synth_asign_block_3\l__scfg_backedge_var_0__ = 1
-jump targets: ('tail_region_2',)
-back edges: ()" shape=rect]
+					color=green label="branch_region_5\n
+jump targets: ('tail_region_2',)" shape=rect style=rounded
+					synth_asign_block_3 [label="synth_asign_block_3\n\l__scfg_backedge_var_0__ = 1\l
+jump targets: ('tail_region_2',)" shape=rect style=rounded]
 				}
 				subgraph cluster_tail_region_2 {
-					color=purple label="tail_region_2
-jump targets: ('tail_region_1',)
-back edges: ()"
-					synth_tail_block_0 [label="synth_tail_block_0\l
-jump targets: ('tail_region_1',)
-back edges: ()" shape=rect]
+					color=purple label="tail_region_2\n
+jump targets: ('tail_region_1',)" shape=rect style=rounded
+					synth_tail_block_0 [label="synth_tail_block_0\n
+jump targets: ('tail_region_1',)" shape=rect style=rounded]
 				}
 			}
 			subgraph cluster_branch_region_3 {
-				color=green label="branch_region_3
-jump targets: ('tail_region_1',)
-back edges: ()"
-				2 [label="2\l
-jump targets: ('4',)
-back edges: ()" shape=rect]
-				4 [label="4\l
-jump targets: ('synth_asign_block_4',)
-back edges: ()" shape=rect]
-				synth_asign_block_4 [label="synth_asign_block_4\l__scfg_backedge_var_0__ = 0\l__scfg_control_var_0__ = 0
-jump targets: ('tail_region_1',)
-back edges: ()" shape=rect]
+				color=green label="branch_region_3\n
+jump targets: ('tail_region_1',)" shape=rect style=rounded
+				2 [label="2\n
+jump targets: ('4',)" shape=rect style=rounded]
+				4 [label="4\n
+jump targets: ('synth_asign_block_4',)" shape=rect style=rounded]
+				synth_asign_block_4 [label="synth_asign_block_4\n\l__scfg_backedge_var_0__ = 0\l__scfg_control_var_0__ = 0\l
+jump targets: ('tail_region_1',)" shape=rect style=rounded]
 			}
 			subgraph cluster_tail_region_1 {
-				color=purple label="tail_region_1
+				color=purple label="tail_region_1\n
+jump targets: ('5',)" shape=rect style=rounded
+				synth_exit_latch_block_0 [label="synth_exit_latch_block_0\n\lvariable: __scfg_backedge_var_0__\l1 → 5\l0 → head_region_1\l
 jump targets: ('5',)
-back edges: ()"
-				synth_exit_latch_block_0 [label="synth_exit_latch_block_0\lvariable: __scfg_backedge_var_0__\l1=>5\l0=>head_region_1
-jump targets: ('5',)
-back edges: ('head_region_1',)" shape=rect]
+back edges: ('head_region_1',)" shape=rect style=rounded]
 			}
 		}
 	}


### PR DESCRIPTION
This updates the rendering code for Python source based SCFGs such that the layout of the information inside the nodes has redundancies reduced and there is sufficient whitespace to visually segment the information contained within the nodes.

Before:

<img width="399" alt="Screenshot 2024-08-07 at 11 24 48" src="https://github.com/user-attachments/assets/b9717cc5-fbda-4311-9f94-7439b75ce1e0">

After:

<img width="399" alt="Screenshot 2024-08-07 at 11 24 21" src="https://github.com/user-attachments/assets/45de7e32-fa19-48b3-91c7-ebc0302c5219">
