### PR TITLE
improve name of transformed function

### DIFF
--- a/numba_rvsdg/core/datastructures/ast_transforms.py
+++ b/numba_rvsdg/core/datastructures/ast_transforms.py
@@ -680,7 +680,7 @@ class SCFG2ASTTransformer:
                 continue
             body.extend(self.codegen(block))
         return ast.FunctionDef(
-            name="transformed_function",
+            name=f"transformed_{original.name}",
             args=original.args,
             body=cast(list[ast.stmt], body),
             decorator_list=original.decorator_list,


### PR DESCRIPTION
Instead of every transformed function being called `transformed_function`, it is now called `transformed_ORIGINAL` where `ORIGINAL` is the original name of the function.

The tests do not need to be updated, because all the test functions are called `function` already.